### PR TITLE
Allow usage of API Key in installed version of Transcribe

### DIFF
--- a/GPTResponder.py
+++ b/GPTResponder.py
@@ -1,9 +1,9 @@
 import openai
-from keys import OPENAI_API_KEY
+import GlobalVars
 from prompts import create_prompt, INITIAL_RESPONSE
 import time
 
-openai.api_key = OPENAI_API_KEY
+openai.api_key = GlobalVars.TranscriptionGlobals().api_key
 # Number of phrases to use for generating a response
 MAX_PHRASES = 10
 

--- a/GlobalVars.py
+++ b/GlobalVars.py
@@ -1,13 +1,13 @@
 import queue
 from AudioTranscriber import AudioTranscriber
-# from GPTResponder import GPTResponder
 import AudioRecorder
 import customtkinter as ctk
 import Singleton
 
 
 class TranscriptionGlobals(Singleton.Singleton):
-    # Global constants for audio processing. It is implemented as a singleton
+    """Global constants for audio processing. It is implemented as a Singleton class.
+    """
 
     audio_queue: queue.Queue = None
     user_audio_recorder: AudioRecorder.DefaultMicRecorder = None

--- a/GlobalVars.py
+++ b/GlobalVars.py
@@ -1,11 +1,12 @@
 import queue
 from AudioTranscriber import AudioTranscriber
-from GPTResponder import GPTResponder
+# from GPTResponder import GPTResponder
 import AudioRecorder
 import customtkinter as ctk
+import Singleton
 
 
-class TranscriptionGlobals(object):
+class TranscriptionGlobals(Singleton.Singleton):
     # Global constants for audio processing. It is implemented as a singleton
 
     audio_queue: queue.Queue = None
@@ -14,20 +15,18 @@ class TranscriptionGlobals(object):
     # Global for transcription from speaker, microphone
     transcriber: AudioTranscriber = None
     # Global for responses from openAI API
-    responder: GPTResponder = None
+    responder = None
     # Global for determining whether to seek responses from openAI API
     freeze_state: list = None
     freeze_button: ctk.CTkButton = None
+    api_key: str = None
 
-    def __new__(cls):
-        if not hasattr(cls, 'instance'):
-            cls.instance = super(TranscriptionGlobals, cls).__new__(cls)
-        return cls.instance
-
-    def __init__(self):
+    def __init__(self, key: str = 'API_KEY'):
         if self.audio_queue is None:
             self.audio_queue = queue.Queue()
         if self.user_audio_recorder is None:
             self.user_audio_recorder = AudioRecorder.DefaultMicRecorder()
         if self.speaker_audio_recorder is None:
             self.speaker_audio_recorder = AudioRecorder.DefaultSpeakerRecorder()
+        if self.api_key is None:
+            self.api_key = key

--- a/README.md
+++ b/README.md
@@ -73,25 +73,11 @@ Upon initiation, Transcribe will begin transcribing microphone input and speaker
 
 The --api flag will use the whisper api for transcriptions. This significantly enhances transcription speed and accuracy, and it works in most languages (rather than just English without the flag). However, keep in mind, using the Whisper API consumes OpenAI credits than using the local model. This increased cost is attributed to the advanced features and capabilities that the Whisper API provides. Despite the additional expense, the substantial improvements in speed and transcription accuracy may make it a worthwhile for your use case.
 
-### Windows specific installs
+### Crating Windows installs
 
-(Optional) Install Winrar from https://www.win-rar.com/.
+Install Winrar from https://www.win-rar.com/.
 
 Required for generating binaries from python code. If you do not intend to generate binaries and are only writing python code, you do not need to install winrar. 
-
-## Software Installation
-
-Download the zip file from 
-```
-https://drive.google.com/file/d/1EIz10Nvzc--A8W37YKfWgEChHYxrgvZz/view?usp=sharing
-``` 
-Unzip the files in a folder.
-
-Execute the file `transcribe\transcribe.exe\transcribe.exe`
-
-**Note: Currently, the software installation version only supports transcription.**
-
-Alternatively,
 
 In the file ```generate_binary.bat``` replace these paths at the top of the file to paths specific to your machine. 
 
@@ -105,6 +91,26 @@ SET WINRAR=C:\Program Files\WinRAR\winRAR.exe
 ```
 
 Run ```generate_binary.bat``` file by replacing paths at the top of the file to the ones in your local machine. It should generate a zip file with everything compiled. To run the program simply go to zip file > transcribe.exe.
+
+## Software Installation
+
+1. Download the zip file from
+```
+https://drive.google.com/file/d/1EIz10Nvzc--A8W37YKfWgEChHYxrgvZz/view?usp=sharing
+```
+2. Unzip the files in a folder.
+
+3. (Optional) Replace the Open API key in `parameters.yaml` file in the transcribe directory:
+
+   Replace the Open API key in `parameters.yaml` file manually. Open in a text editor and alter the line:
+
+      ```
+        api_key: 'API_KEY'
+      ```
+      Replace "API KEY" with the actual OpenAI API key. Save the file.
+
+4. Execute the file `transcribe\transcribe.exe\transcribe.exe`
+
 
 ### ⚡️ Limitations ⚡️
 

--- a/README.md
+++ b/README.md
@@ -46,18 +46,12 @@ Please run these commands in a PowerShell window with administrator privileges. 
    pip install -r requirements.txt
    ```
    
-4. (Optional) Replace the Open API key in `keys.py` file in the transcribe directory:
+4. (Optional) Replace the Open API key in `parameters.yaml` file in the transcribe directory:
 
-   - Option 1: Use command prompt. Run the following command, ensuring to replace "API KEY" with the actual OpenAI API key:
-
-      ```
-      python -c "with open('keys.py', 'w', encoding='utf-8') as f: f.write('OPENAI_API_KEY=\"API KEY\"')"
-      ```
-
-   - Option 2: Replace the Open API key in keys.py file manually. Open in a text editor and enter the following content:
+   Replace the Open API key in `parameters.yaml` file manually. Open in a text editor and alter the line:
    
       ```
-      OPENAI_API_KEY="API KEY"
+        api_key: 'API_KEY'
       ```
       Replace "API KEY" with the actual OpenAI API key. Save the file.
 

--- a/Singleton.py
+++ b/Singleton.py
@@ -1,0 +1,10 @@
+class Singleton(object):
+    """ Restricts the instantiation of this class and all its derived classes 
+    to a singular instance.
+    """
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super().__new__(cls, *args, **kwargs)
+        return cls._instance

--- a/configuration.py
+++ b/configuration.py
@@ -1,0 +1,21 @@
+import yaml
+import sys
+import Singleton
+
+class Config(Singleton.Singleton):
+    """A Singleton object with all configuration data
+    """
+    data: dict = None
+
+    def __init__(self, filename: str = 'parameters.yaml'):
+        with open(filename, mode='r', encoding='utf-8') as config_file:
+            try:
+                if self.data is None:
+                    self.data = yaml.load(stream=config_file, Loader=yaml.CLoader)
+            except ImportError as err:
+                print(f'Failed to load yaml file: {filename}.')
+                print(f'Error: {err}')
+                sys.exit(1)
+
+    def get_data(self) -> dict:
+        return self.data

--- a/generate_binary.bat
+++ b/generate_binary.bat
@@ -34,6 +34,7 @@ if not exist %ASSETS_DIR_DEST% mkdir %ASSETS_DIR_DEST%
 
 REM Copy appropriate files to the dir
 copy %SOURCE_DIR%\tiny.en.pt %OUTPUT_DIR%\dist\%EXECUTABLE_NAME%\tiny.en.pt
+copy %SOURCE_DIR%\parameters.yaml %OUTPUT_DIR%\dist\%EXECUTABLE_NAME%\parameters.yaml
 copy %ASSETS_DIR_SRC%\mel_filters.npz %ASSETS_DIR_DEST%
 copy %ASSETS_DIR_SRC%\gpt2.tiktoken %ASSETS_DIR_DEST%
 

--- a/keys.py
+++ b/keys.py
@@ -1,1 +1,0 @@
-OPENAI_API_KEY = "API_KEY"

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -1,0 +1,2 @@
+OpenAI:
+  api_key: 'API_KEY'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyinstaller==5.13.0
 --extra-index-url https://download.pytorch.org/whl/cu117
 torch
 pyperclip
+PyYAML

--- a/ui.py
+++ b/ui.py
@@ -5,7 +5,7 @@ import AudioTranscriber
 import prompts
 from language import LANGUAGES_DICT
 import customtkinter as ctk
-import globals
+import GlobalVars
 
 
 UI_FONT_SIZE = 20
@@ -13,10 +13,10 @@ UI_FONT_SIZE = 20
 
 class ui_callbacks:
 
-    global_vars: globals.TranscriptionGlobals
+    global_vars: GlobalVars.TranscriptionGlobals
 
     def __init__(self):
-        self.global_vars = globals.TranscriptionGlobals()
+        self.global_vars = GlobalVars.TranscriptionGlobals()
 
     def copy_to_clipboard(self):
         """Copy transcription text data to clipboard
@@ -109,7 +109,7 @@ def create_ui_components(root):
     root.geometry("1000x600")
 
     ui_cb = ui_callbacks()
-    global_vars = globals.TranscriptionGlobals()
+    global_vars = GlobalVars.TranscriptionGlobals()
 
     # Create the menu bar
     menubar = tk.Menu(root)


### PR DESCRIPTION
- Add a parameters.yaml for configurable parameters
- Allow specification of api key as a command line arg
- Add api key to parameters.yaml file
- Api key specified in cmd line args take precedence over parameters.yaml file
- Create a base Singleton class
- Implement Config object (Singleton) for reading from parameters file
- Redo implementation of Transcription Globals class as Singleton using Singleton base class
- Add parameters.yaml file to installer zip for installed version of Transcribe
