### PR TITLE
Optimize LLM usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .venv/
 venv
 output
+tiny.pt

--- a/GPTResponder.py
+++ b/GPTResponder.py
@@ -4,9 +4,10 @@ from prompts import create_prompt, INITIAL_RESPONSE
 import time
 import conversation
 import constants
+import configuration
 
 # Number of phrases to use for generating a response
-MAX_PHRASES = 10
+MAX_PHRASES = 20
 
 
 class GPTResponder:
@@ -16,12 +17,14 @@ class GPTResponder:
         self.gl_vars = GlobalVars.TranscriptionGlobals()
         openai.api_key = self.gl_vars.api_key
         self.conversation = convo
+        self.config = configuration.Config().get_data()
+        self.model = self.config['OpenAI']['ai_model']
 
-    def generate_response_from_transcript(self, transcript):
+    def generate_response_from_transcript_no_check(self, transcript):
         try:
             prompt_content = create_prompt(transcript)
             response = openai.ChatCompletion.create(
-                    model="gpt-3.5-turbo-0301",
+                    model=self.model,
                     messages=[{"role": "system", "content": prompt_content}],
                     temperature=0.0
             )
@@ -34,12 +37,17 @@ class GPTResponder:
         except:
             return ''
 
+    def generate_response_from_transcript(self, transcript):
+        """Ping OpenAI LLM model to get response from the Assistant
+        """
+
+        if self.gl_vars.freeze_state[0]:
+            return ''
+
+        return generate_response_from_transcript_no_check(self, transcript)
+
     def respond_to_transcriber(self, transcriber):
         while True:
-            if self.gl_vars.freeze_state[0]:
-                print('Skip getting response from LLM')
-                time.sleep(self.response_interval)
-                continue
 
             if transcriber.transcript_changed_event.is_set():
                 start_time = time.time()

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,7 @@
+"""Globally used constants
+"""
+
+PERSONA_YOU = "You"
+PERSONA_ASSISTANT = "Assistant"
+PERSONA_SYSTEM = "System"
+PERSONA_SPEAKER = "Speaker"

--- a/conversation.py
+++ b/conversation.py
@@ -34,8 +34,6 @@ class Conversation:
         if pop:
             transcript.pop()
         transcript.append((f"{persona}: [{text}]\n\n", time_spoken))
-        print(f"update_conversation: {time_spoken}: {persona}: [{text}]\n\n")
-        print(f"Length: {len(transcript)}")
 
     def get_conversation(self,
                          sources: list = None,

--- a/conversation.py
+++ b/conversation.py
@@ -1,0 +1,62 @@
+from heapq import merge
+import constants
+import configuration
+
+
+class Conversation:
+    """Encapsulates the complete conversation.
+    Has text from Speakers, Microphone, LLM, Instructions to LLM
+    """
+
+    def __init__(self):
+        self.transcript_data = {constants.PERSONA_SYSTEM: [],
+                                constants.PERSONA_YOU: [],
+                                constants.PERSONA_SPEAKER: [],
+                                constants.PERSONA_ASSISTANT: []}
+        config = configuration.Config().get_data()
+
+    def clear_conversation_data(self):
+        """Clear all conversation data
+        """
+        self.transcript_data[constants.PERSONA_YOU].clear()
+        self.transcript_data[constants.PERSONA_SPEAKER].clear()
+        self.transcript_data[constants.PERSONA_SYSTEM].clear()
+        self.transcript_data[constants.PERSONA_ASSISTANT].clear()
+
+    def update_conversation(self, persona: str, text: str, time_spoken, pop: bool = False):
+        """Update conversation with new data
+        Args:
+        person: person this part of conversation is attributed to
+        text: Actual words
+        time_spoken: Time at which conversation happened, this is typically reported in local time
+        """
+        transcript = self.transcript_data[persona]
+        if pop:
+            transcript.pop()
+        transcript.append((f"{persona}: [{text}]\n\n", time_spoken))
+        print(f"update_conversation: {time_spoken}: {persona}: [{text}]\n\n")
+        print(f"Length: {len(transcript)}")
+
+    def get_conversation(self,
+                         sources: list = None,
+                         length: int = 0):
+        """Get the complete transcript
+        Args:
+        sources: Get data from which sources (You, Speaker, Assistant, System)
+        length: Get the last length elements from the audio transcript.
+                Default value = 0, gives the complete transcript
+        """
+        if sources is None:
+            sources = [constants.PERSONA_YOU,
+                       constants.PERSONA_SPEAKER,
+                       constants.PERSONA_ASSISTANT,
+                       constants.PERSONA_SYSTEM]
+
+        combined_transcript = list(merge(
+            self.transcript_data[constants.PERSONA_YOU][-length:],
+            self.transcript_data[constants.PERSONA_SPEAKER][-length:],
+            self.transcript_data[constants.PERSONA_ASSISTANT][-length:],
+            self.transcript_data[constants.PERSONA_SYSTEM][-length:],
+            key=lambda x: x[1]))
+        combined_transcript = combined_transcript[-length:]
+        return "".join([t[0] for t in combined_transcript])

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -1,2 +1,11 @@
 OpenAI:
   api_key: 'API_KEY'
+
+# Possible model values
+# gpt-3.5-turbo, gpt-3.5-turbo-16k, gpt-3.5-turbo-0613, gpt-3.5-turbo-16k-0613
+# gpt-4, gpt-4-0613, gpt-4-32k, gpt-4-32k-0613
+# Legacy models
+# text-davinci-003, text-davinci-002, code-davinci-002
+# See this link for available models
+# https://platform.openai.com/docs/models/continuous-model-upgrades
+  ai_model: gpt-3.5-turbo-0301


### PR DESCRIPTION
Do not ping LLM if we do not need to. Previously we were always pinging LLM even when response suggestions were off. This was causing unnecessary costs of LLM and delays in UI updates.

Partial refactoring work towards separating conversation into its own object towards forward looking features.
Make OpenAI model configurable in parameters.yaml so it is easier for end user to change it without touching code. With new models like chatgpt 4 being available, end users should be able to change models easily.
