### PR TITLE
Disable mic speaker selectively

### DIFF
--- a/AudioTranscriber.py
+++ b/AudioTranscriber.py
@@ -19,7 +19,8 @@ class AudioTranscriber:
         self.transcript_data = {"You": [], "Speaker": []}
         self.transcript_changed_event = threading.Event()
         self.audio_model = model
-        self.transcribe = True  # By default we start with transcription enabled
+        # Determines if transcription is enabled for the application. By default it is enabled.
+        self.transcribe = True
         self.audio_sources = {
             "You": {
                 "sample_rate": mic_source.SAMPLE_RATE,
@@ -87,8 +88,8 @@ class AudioTranscriber:
             return
         audio_data = sr.AudioData(data, self.audio_sources["You"]["sample_rate"], self.audio_sources["You"]["sample_width"])
         wav_data = io.BytesIO(audio_data.get_wav_data())
-        with open(temp_file_name, 'w+b') as f:
-            f.write(wav_data.read())
+        with open(temp_file_name, 'w+b') as file_handle:
+            file_handle.write(wav_data.read())
 
     def process_speaker_data(self, data, temp_file_name):
         if not self.transcribe:

--- a/README.md
+++ b/README.md
@@ -143,9 +143,12 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## ➕ Enhancements from base repository ➕
 - Do not need Open AI key, paid Open AI account to use the complete functionality
+- Allow users selective disabling of mic, speaker audio input
 - Allow users to add contextual information to provide customized responses to conversation
 - Allows usage of different models for transcription using command line arguments
 - Allow to pause audio transcription
+- List all active devices on the system
+- Allow user to get response from LLM on demand, even when it is disabled at application level
 - Transcribe audio of any video
 - Preserve all conversation text in UI
 - Allow saving conversation to file

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ While Transcribe provides real-time transcription and optional response suggesti
 Incorrect API key provided: API_KEY. You can find your API key at https://platform.openai.com/account/api-keys.
 ```
 
-**Models**: The default install of transcribe has the tiny(72 Mb) model. base (138 Mb), small (461 Mb) models can be downloaded and used for transcription by following instructions using transcribe command line. The larger models provide better quality transcription and they have higher memory requirements.
+**Models**: The default install of transcribe has the tiny(72 Mb) model for english. Other larger models and their multi lingual versions can be downloaded and used for transcription by following instructions using transcribe command line arguments. Larger models provide better quality transcription and they have higher memory requirements.
 
 **Language**: If you are not using the --api flag the Whisper model used in Transcribe is set to English. As a result, it may not accurately transcribe non-English languages or dialects. 
 

--- a/conversation.py
+++ b/conversation.py
@@ -61,10 +61,10 @@ class Conversation:
                        constants.PERSONA_SYSTEM]
 
         combined_transcript = list(merge(
-            self.transcript_data[constants.PERSONA_YOU][-length:],
-            self.transcript_data[constants.PERSONA_SPEAKER][-length:],
-            self.transcript_data[constants.PERSONA_ASSISTANT][-length:],
-            self.transcript_data[constants.PERSONA_SYSTEM][-length:],
+            self.transcript_data[constants.PERSONA_YOU][-length:] if constants.PERSONA_YOU in sources else [],
+            self.transcript_data[constants.PERSONA_SPEAKER][-length:] if constants.PERSONA_SPEAKER in sources else [],
+            self.transcript_data[constants.PERSONA_ASSISTANT][-length:] if constants.PERSONA_ASSISTANT in sources else [],
+            self.transcript_data[constants.PERSONA_SYSTEM][-length:] if constants.PERSONA_SYSTEM in sources else [],
             key=lambda x: x[1]))
         combined_transcript = combined_transcript[-length:]
         return "".join([t[0] for t in combined_transcript])

--- a/custom_speech_recognition/audio.py
+++ b/custom_speech_recognition/audio.py
@@ -12,14 +12,14 @@ import wave
 class AudioData(object):
     """
     Creates a new ``AudioData`` instance, which represents mono audio data.
-
-    The raw audio data is specified by ``frame_data``, which is a sequence of bytes representing audio samples. This is the frame data structure used by the PCM WAV format.
-
-    The width of each sample, in bytes, is specified by ``sample_width``. Each group of ``sample_width`` bytes represents a single audio sample.
-
+    The raw audio data is specified by ``frame_data``, which is a sequence of bytes representing
+    audio samples. This is the frame data structure used by the PCM WAV format.
+    The width of each sample, in bytes, is specified by ``sample_width``. Each group of
+    ``sample_width`` bytes represents a single audio sample.
     The audio data is assumed to have a sample rate of ``sample_rate`` samples per second (Hertz).
-
-    Usually, instances of this class are obtained from ``recognizer_instance.record`` or ``recognizer_instance.listen``, or in the callback for ``recognizer_instance.listen_in_background``, rather than instantiating them directly.
+    Usually, instances of this class are obtained from ``recognizer_instance.record``
+    or ``recognizer_instance.listen``, or in the callback for
+    ``recognizer_instance.listen_in_background``, rather than instantiating them directly.
     """
 
     def __init__(self, frame_data, sample_rate, sample_width):
@@ -33,9 +33,11 @@ class AudioData(object):
 
     def get_segment(self, start_ms=None, end_ms=None):
         """
-        Returns a new ``AudioData`` instance, trimmed to a given time interval. In other words, an ``AudioData`` instance with the same audio data except starting at ``start_ms`` milliseconds in and ending ``end_ms`` milliseconds in.
-
-        If not specified, ``start_ms`` defaults to the beginning of the audio, and ``end_ms`` defaults to the end.
+        Returns a new ``AudioData`` instance, trimmed to a given time interval. In other words,
+        an ``AudioData`` instance with the same audio data except starting at ``start_ms``
+        milliseconds in and ending ``end_ms`` milliseconds in.
+        If not specified, ``start_ms`` defaults to the beginning of the audio, and ``end_ms``
+        defaults to the end.
         """
         assert (
             start_ms is None or start_ms >= 0
@@ -125,8 +127,8 @@ class AudioData(object):
                     raw_data, self.sample_width, convert_width
                 )
 
-        # if the output is 8-bit audio with unsigned samples, convert the samples we've been treating
-        # as signed to unsigned again
+        # if the output is 8-bit audio with unsigned samples, convert the samples
+        # we've been treating as signed to unsigned again
         if convert_width == 1:
             raw_data = audioop.bias(
                 raw_data, 1, 128
@@ -197,7 +199,7 @@ class AudioData(object):
             audioop, "byteswap"
         ):  # ``audioop.byteswap`` was only added in Python 3.4
             raw_data = audioop.byteswap(raw_data, sample_width)
-        else:  
+        else:
             # manually reverse the bytes of each sample, which is slower but
             # works well enough as a fallback
             raw_data = raw_data[sample_width - 1:: -1] + b"".join(

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import customtkinter as ctk
 from AudioTranscriber import AudioTranscriber
 from GPTResponder import GPTResponder
 import AudioRecorder as ar
+# from audio_player import AudioPlayer
 import TranscriberModels
 import interactions
 import ui
@@ -62,9 +63,15 @@ def main():
                           help='List all audio drivers and audio devices on this machine. \
                             \nUse this list index to select the microphone, speaker device for transcription.')
     cmd_args.add_argument('-mi', '--mic_device_index', action='store', default=None, type=int,
-                          help='Device index of the microphone for capturing sound.')
+                          help='Device index of the microphone for capturing sound.'
+                          '\nDevice index can be obtained using the -l option.')
     cmd_args.add_argument('-si', '--speaker_device_index', action='store', default=None, type=int,
-                          help='Device index of the speaker for capturing sound.')
+                          help='Device index of the speaker for capturing sound.'
+                          '\nDevice index can be obtained using the -l option.')
+    cmd_args.add_argument('-dm', '--disable_mic', action='store_true',
+                          help='Enable transcription from Microphone')
+    cmd_args.add_argument('-ds', '--disable_speaker', action='store_true',
+                          help='Enable transcription from Speaker')
     args = cmd_args.parse_args()
 
     # Initiate config
@@ -91,6 +98,14 @@ def main():
     if args.speaker_device_index is not None:
         print('Override default speaker with device specified on command line.')
         global_vars.speaker_audio_recorder.set_device(index=args.speaker_device_index)
+
+    if args.disable_mic:
+        print('Disabling Microphone')
+        global_vars.user_audio_recorder.disable()
+
+    if args.disable_speaker:
+        print('Disabling Speaker')
+        global_vars.speaker_audio_recorder.disable()
 
     try:
         subprocess.run(["ffmpeg", "-version"],
@@ -144,6 +159,7 @@ def main():
                                                global_vars.speaker_audio_recorder.source,
                                                model,
                                                convo=convo)
+    # global_vars.audio_player = AudioPlayer(convo=convo)
     transcribe_thread = threading.Thread(target=global_vars.transcriber.transcribe_audio_queue,
                                          name='Transcribe',
                                          args=(global_vars.audio_queue,))
@@ -157,6 +173,11 @@ def main():
                                       args=(global_vars.transcriber,))
     respond_thread.daemon = True
     respond_thread.start()
+
+    # audio_response_thread = threading.Thread(target=global_vars.audio_player.play_audio_loop,
+    #                                          name='AudioResponse')
+    # audio_response_thread.daemon = True
+    # audio_response_thread.start()
 
     print("READY")
 


### PR DESCRIPTION
Allow disabling mic, speaker selectively using command line arguments.
Fixed a bug in conversation.py - the list was not filtered correctly based on input arguments.