### PR TITLE
Clear transcript periodically, if configured as such by the user

### DIFF
--- a/AudioTranscriber.py
+++ b/AudioTranscriber.py
@@ -149,10 +149,10 @@ class AudioTranscriber:
                 Default value = 0, gives the complete transcript
         """
         # This data should be retrieved from the conversation object.
-        combined_transcript = list(merge(
-            self.transcript_data["You"], self.transcript_data["Speaker"],
-            key=lambda x: x[1], reverse=False))
-        combined_transcript = combined_transcript[-length:]
+        # combined_transcript = list(merge(
+        #    self.transcript_data["You"], self.transcript_data["Speaker"],
+        #    key=lambda x: x[1], reverse=False))
+        # combined_transcript = combined_transcript[-length:]
         # current_return_val = "".join([t[0] for t in combined_transcript])
         sources = [
             constants.PERSONA_YOU,
@@ -184,8 +184,8 @@ class AudioTranscriber:
           text: updated text
     """
         with self.mutex:
-            # This method can be invoked from 2 different contexts. Mutex ensures integrity
-            # of data for race conditions.
+            # This method can be invoked from 2 different contexts.
+            # Mutex ensures integrity of data for race conditions.
             root_logger.info(AudioTranscriber.clear_transcriber_context.__name__)
             self.clear_transcript_data()
             with audio_queue.mutex:

--- a/AudioTranscriber.py
+++ b/AudioTranscriber.py
@@ -171,7 +171,6 @@ class AudioTranscriber:
         """Clear transcript data at a specified interval if needed.
         Args:
           audio_queue: queue object with reference to audio files
-
         """
         while True:
             if self.clear_transcript_periodically:
@@ -184,10 +183,13 @@ class AudioTranscriber:
           textbox: textbox to be updated
           text: updated text
     """
-        root_logger.info(AudioTranscriber.clear_transcriber_context.__name__)
-        self.clear_transcript_data()
-        with audio_queue.mutex:
-            audio_queue.queue.clear()
+        with self.mutex:
+            # This method can be invoked from 2 different contexts. Mutex ensures integrity
+            # of data for race conditions.
+            root_logger.info(AudioTranscriber.clear_transcriber_context.__name__)
+            self.clear_transcript_data()
+            with audio_queue.mutex:
+                audio_queue.queue.clear()
 
     def clear_transcript_data(self):
         """

--- a/GPTResponder.py
+++ b/GPTResponder.py
@@ -1,6 +1,6 @@
 import datetime
 import time
-import pprint
+# import pprint
 import openai
 import GlobalVars
 import prompts

--- a/main.py
+++ b/main.py
@@ -182,6 +182,12 @@ def main():
     audio_response_thread.daemon = True
     audio_response_thread.start()
 
+    clear_transcript_thread = threading.Thread(target=global_vars.transcriber.clear_transcript_data_loop,
+                                               name='ClearTranscript',
+                                               args=(global_vars.audio_queue,))
+    clear_transcript_thread.daemon = True
+    clear_transcript_thread.start()
+
     print("READY")
 
     root.grid_rowconfigure(0, weight=100)

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -46,4 +46,9 @@ OpenAI:
 General:
   log_file: 'Transcribe.log'
 # Attempt transcription of the sound file after these number of seconds
-  transcript_audio_duration_seconds: 1
+  transcript_audio_duration_seconds: 3
+# These two parameters are used together.
+# Setting clear_transcript_periodically: yes will clear transcript data at a regular interval
+# clear_transcript_interval_seconds is applicable when clear_transcript_periodically is set to Yes
+  clear_transcript_periodically: No # Possible values are Yes, No
+  clear_transcript_interval_seconds: 30

--- a/prompts.py
+++ b/prompts.py
@@ -1,6 +1,5 @@
 # import datetime
 # import pprint
-# from CustomPrompts import PREAMBLE, EPILOGUE
 import configuration
 
 INITIAL_RESPONSE = '👋 Welcome to Transcribe 🤝'

--- a/ui.py
+++ b/ui.py
@@ -200,8 +200,8 @@ def create_ui_components(root):
     editmenu = tk.Menu(menubar, tearoff=False)
 
     # Add a "Clear Audio Transcript" menu item to the file menu
-    editmenu.add_command(label="Clear Audio Transcript", command=lambda: clear_transcriber_context(
-        global_vars.transcriber, global_vars.audio_queue))
+    editmenu.add_command(label="Clear Audio Transcript", command=lambda:
+                         global_vars.transcriber.clear_transcriber_context(global_vars.audio_queue))
 
     # Add a "Copy To Clipboard" menu item to the file menu
     editmenu.add_command(label="Copy Transcript to Clipboard", command=ui_cb.copy_to_clipboard)

--- a/ui.py
+++ b/ui.py
@@ -147,24 +147,12 @@ def update_response_ui(responder: GPTResponder,
 
         update_interval = int(update_interval_slider.get())
         responder.update_response_interval(update_interval)
-        update_interval_slider_label.configure(text=f'Update Response interval: {update_interval} seconds')
+        update_interval_slider_label.configure(text=f'Update Response interval: '
+                                               f'{update_interval} seconds')
 
     textbox.after(300, update_response_ui, responder, textbox,
                   update_interval_slider_label, update_interval_slider,
                   freeze_state)
-
-
-def clear_transcriber_context(transcriber: AudioTranscriber,
-                              audio_queue: queue.Queue):
-    """Reset the transcriber
-        Args:
-          textbox: textbox to be updated
-          text: updated text
-    """
-    root_logger.info(clear_transcriber_context.__name__)
-    transcriber.clear_transcript_data()
-    with audio_queue.mutex:
-        audio_queue.queue.clear()
 
 
 def create_ui_components(root):


### PR DESCRIPTION
- Allow user to clear transcript periodically based on configuration
- Slight refactor of ui callbacks to remove redundant code.
- Change default value of `transcript_audio_duration_seconds` based on user feedback

This is all done through `parameters.yaml` file.
```
# These two parameters are used together.
# Setting clear_transcript_periodically: yes will clear transcript data at a regular interval
# clear_transcript_interval_seconds is applicable when clear_transcript_periodically is set to Yes
  clear_transcript_periodically: No # Possible values are Yes, No
  clear_transcript_interval_seconds: 30
```

Future work to allow for configuration in the UI.

This resolves issue #72 

FYI @sdhreddy