### PR TITLE
Allow to override all command line arguments using parameters

### DIFF
--- a/main.py
+++ b/main.py
@@ -225,6 +225,7 @@ def handle_args(args: argparse.Namespace, global_vars: GlobalVars, config: dict)
 
     if args.speaker_device_index is not None:
         print('[INFO] Override default speaker with device specified on command line.')
+        config['General']['speaker_device_index'] = int(args.speaker_device_index)
         global_vars.speaker_audio_recorder.set_device(index=args.speaker_device_index)
 
     # Command line arg for api_key takes preference over api_key specified in parameters.yaml file

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -76,3 +76,23 @@ General:
 # clear_transcript_interval_seconds is applicable when clear_transcript_periodically is set to Yes
   clear_transcript_periodically: No # Possible values are Yes, No
   clear_transcript_interval_seconds: 90
+# Determines whether to use API for STT or not. This option is applicable only for online services.
+# This option has no affect on offline services.
+# This is equivalent to -stt (speech_to_text) argument on command line.
+# Command line argument takes precedence over value specified in parameters.yaml
+  use_api: False
+# Index of microphone device. Value of -1 indicates it is not set.
+# This is equivalent to -mi (mic_device_index) argument on command line
+# Command line argument takes precedence over value specified in parameters.yaml
+  mic_device_index: 2
+# Index of speaker device.  Value of -1 indicates it is not set.
+# This is equivalent to -si (speaker_device_index) argument on command line
+# Command line argument takes precedence over value specified in parameters.yaml
+  speaker_device_index: -1
+# Disable Microphone
+# This is equivalent to -dm (disable_mic) argument on command line
+# Command line argument takes precedence over value specified in parameters.yaml
+  disable_mic: False
+# This is equivalent to -ds (disable_speaker) argument on command line
+# Command line argument takes precedence over value specified in parameters.yaml
+  disable_speaker: False

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -84,7 +84,7 @@ General:
 # Index of microphone device. Value of -1 indicates it is not set.
 # This is equivalent to -mi (mic_device_index) argument on command line
 # Command line argument takes precedence over value specified in parameters.yaml
-  mic_device_index: 2
+  mic_device_index: -1
 # Index of speaker device.  Value of -1 indicates it is not set.
 # This is equivalent to -si (speaker_device_index) argument on command line
 # Command line argument takes precedence over value specified in parameters.yaml

--- a/ui.py
+++ b/ui.py
@@ -1,6 +1,7 @@
 import threading
 import datetime
 import tkinter as tk
+import webbrowser
 import pyperclip
 import customtkinter as ctk
 import AudioTranscriber
@@ -10,6 +11,7 @@ import GlobalVars
 import GPTResponder
 import app_logging as al
 import constants
+
 
 root_logger = al.get_logger()
 UI_FONT_SIZE = 20
@@ -106,6 +108,10 @@ class ui_callbacks:
             self.global_vars.filemenu.entryconfigure(1, label="Pause Transcription")
         else:
             self.global_vars.filemenu.entryconfigure(1, label="Start Transcription")
+
+    def open_link(self, url: str):
+        """Open the link in a web browser"""
+        webbrowser.open(url=url, new=2)
 
 
 def write_in_textbox(textbox: ctk.CTkTextbox, text: str):
@@ -263,8 +269,15 @@ def create_ui_components(root):
     lang_combobox = ctk.CTkOptionMenu(root, width=15, values=list(LANGUAGES_DICT.values()))
     lang_combobox.grid(row=3, column=0, ipadx=60, padx=10, sticky="wn")
 
+    github_link = ctk.CTkLabel(root, text="Transcribe Github Repo", text_color="#639cdc", cursor="hand2")
+    github_link.grid(row=3, column=0, padx=10, pady=10, sticky="n")
+
+    star_link = ctk.CTkLabel(root, text="Star the Repo if you like the app", text_color="#FFFCF2", cursor="hand2")
+    star_link.grid(row=3, column=0, padx=10, pady=10, sticky="en")
+
     # Order of returned components is important.
     # Add new components to the end
     return [transcript_textbox, response_textbox, update_interval_slider,
             update_interval_slider_label, freeze_button, lang_combobox,
-            filemenu, response_now_button, read_response_now_button, editmenu]
+            filemenu, response_now_button, read_response_now_button, editmenu,
+            github_link, star_link]


### PR DESCRIPTION
Allow to override all command line parameters using values in parameters.yaml or override.yaml file.

This change was motivated by the #99.
If users tend to use non default speaker or microphone, or want to use a specific STT model each time, it is easier to specify these parameters in override.yaml file than specifying them each time as arguments at application invocation time.

This will open the path to specifying different configs for different situations and packaging.

Resolves #99 
