### PR TITLE
Python compatibility with 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Follow below steps to run transcribe on your local machine.
 
 ### 📋 Prerequisites
 
-- Python >=3.11.0 and < 3.12.0
+- Python >=3.11.0
 - (Optional) An OpenAI API key (set up a paid [OpenAI account](https://platform.openai.com/))
 - Windows OS (Not tested on others)
 - FFmpeg

--- a/app/transcribe/requirements.txt
+++ b/app/transcribe/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.24.3
+numpy==1.26.4
 openai-whisper==20231117
 Wave==0.0.2
 openai==1.13.3


### PR DESCRIPTION
Transcribe can now be used with Python 3.12.
The underlying issue was with the PyAudioWPatch library and compatibility with the latest numpy version.

PyAudioWPatch issue is resolved here - https://github.com/s0d3s/PyAudioWPatch/issues/16
