### PR TITLE
DRAFT: Use static-ffmpeg instead of installing ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Latest Binary
 - Generated: 2024-01-30
 - Git version: bbe1f4
 
+[comment]: <> (Remove section for install of ffmpeg)
 1. Install ffmpeg
 
 First, install Chocolatey, a package manager for Windows.

--- a/app/transcribe/app_utils.py
+++ b/app/transcribe/app_utils.py
@@ -5,6 +5,7 @@ from global_vars import TranscriptionGlobals
 from audio_player import AudioPlayer  # noqa: E402 pylint: disable=C0413
 from gpt_responder import InferenceResponderFactory, InferenceEnum
 from audio_transcriber import WhisperCPPTranscriber, WhisperTranscriber, DeepgramTranscriber
+import static_ffmpeg
 sys.path.append('../..')
 import interactions  # noqa: E402 pylint: disable=C0413
 from sdk import transcriber_models as tm  # noqa: E402 pylint: disable=C0413
@@ -97,6 +98,7 @@ def initiate_app_threads(global_vars: TranscriptionGlobals,
 def start_ffmpeg():
     """Start ffmpeg library"""
     try:
+        static_ffmpeg.add_paths()
         subprocess.run(["ffmpeg", "-version"],  # nosec
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL,

--- a/app/transcribe/audio_transcriber.py
+++ b/app/transcribe/audio_transcriber.py
@@ -11,6 +11,7 @@ from abc import abstractmethod
 import wave
 import tempfile
 import pyaudiowpatch as pyaudio
+import static_ffmpeg
 sys.path.append('../..')
 import conversation  # noqa: E402 pylint: disable=C0413
 import constants  # noqa: E402 pylint: disable=C0413
@@ -215,7 +216,7 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
         try:
             # Convert input file to 16khz. That is a requirement for using whisper.cpp
             # ffmpeg -i <input audio filename> -ar 16000 -ac 1 -c:a pcm_s16le -y <output audio file>
-
+            static_ffmpeg.add_paths()
             file_descritor, mod_file_path = tempfile.mkstemp(suffix=".wav")
             os.close(file_descritor)
             # print(f'Convert file {file_path} to 16khz file {mod_file_path}')

--- a/app/transcribe/interactions.py
+++ b/app/transcribe/interactions.py
@@ -105,6 +105,7 @@ def detect_ps():
         return False
     except FileNotFoundError:
         print('Please install Powershell or ensure it is in path.')
+        # Remove comment about ffmpeg
         print('Powershell is required to download models and install ffmpeg')
         return False
 
@@ -148,6 +149,7 @@ def exec_ps(script: str) -> (bool, str):
         return False, ''
     except FileNotFoundError:
         print('Please install Powershell or ensure it is in path.')
+        # Remove comment about ffmpeg
         print('Powershell is required to download models and install ffmpeg')
         return False, ''
 

--- a/app/transcribe/requirements.txt
+++ b/app/transcribe/requirements.txt
@@ -18,3 +18,4 @@ deepgram-sdk==3.2.5
 --extra-index-url https://download.pytorch.org/whl/cu121
 torch
 bandit==1.7.8
+static-ffmpeg

--- a/tsutils/utilities.py
+++ b/tsutils/utilities.py
@@ -163,6 +163,7 @@ def download_using_bits(file_url: str, file_path: str):
         print(f'Failed to download the file: {file_url}')
     except FileNotFoundError:
         print('Please install Powershell or ensure it is in path.')
+        # Remove comment about ffmpeg
         print('Powershell is required to download models and install ffmpeg')
 
 


### PR DESCRIPTION
Related to issue #199. 
Minimal set of changes required for using static-ffmpeg. 
We will revisit this PR once static-ffmpeg has been updated to ffmpeg v7 or higher.