### PR TITLE
Tooltips for disabled buttons

### DIFF
--- a/app/transcribe/requirements.txt
+++ b/app/transcribe/requirements.txt
@@ -3,7 +3,7 @@ openai-whisper==20231117
 Wave==0.0.2
 openai==1.17.1
 customtkinter==5.2.2
-tkinter-tooltip  # Needed to show tooltips for buttons
+tkinter-tooltip  # Needed to show tooltips for ctk components
 PyAudioWPatch==0.2.12.6
 pyperclip
 PyYAML

--- a/app/transcribe/requirements.txt
+++ b/app/transcribe/requirements.txt
@@ -3,6 +3,7 @@ openai-whisper==20231117
 Wave==0.0.2
 openai==1.17.1
 customtkinter==5.2.2
+tkinter-tooltip  # Needed to show tooltips for buttons
 PyAudioWPatch==0.2.12.6
 pyperclip
 PyYAML

--- a/app/transcribe/ui.py
+++ b/app/transcribe/ui.py
@@ -501,17 +501,18 @@ def create_ui_components(root, config: dict):
         read_response_now_button.configure(state='disabled')
         summarize_button.configure(state='disabled')
 
+        tt_msg = 'Add API Key in override.yaml to enable button'
         # Add tooltip for disabled buttons
-        ToolTip(continuous_response_button, msg="Add API Key in override.yaml to enable button",
+        ToolTip(continuous_response_button, msg=tt_msg,
                 delay=0.01, follow=True, parent_kwargs={"padx": 3, "pady": 3},
                 padx=7, pady=7)
-        ToolTip(response_now_button, msg="Add API Key in override.yaml to enable button",
+        ToolTip(response_now_button, msg=tt_msg,
                 delay=0.01, follow=True, parent_kwargs={"padx": 3, "pady": 3},
                 padx=7, pady=7)
-        ToolTip(read_response_now_button, msg="Add API Key in override.yaml to enable button",
+        ToolTip(read_response_now_button, msg=tt_msg,
                 delay=0.01, follow=True, parent_kwargs={"padx": 3, "pady": 3},
                 padx=7, pady=7)
-        ToolTip(summarize_button, msg="Add API Key in override.yaml to enable button",
+        ToolTip(summarize_button, msg=tt_msg,
                 delay=0.01, follow=True, parent_kwargs={"padx": 3, "pady": 3},
                 padx=7, pady=7)
 

--- a/app/transcribe/ui.py
+++ b/app/transcribe/ui.py
@@ -5,6 +5,7 @@ import tkinter as tk
 import webbrowser
 import pyperclip
 import customtkinter as ctk
+from tktooltip import ToolTip
 from audio_transcriber import AudioTranscriber
 import prompts
 from global_vars import TranscriptionGlobals, T_GLOBALS
@@ -497,9 +498,22 @@ def create_ui_components(root, config: dict):
         # Disable buttons that interact with backend services
         continuous_response_button.configure(state='disabled')
         response_now_button.configure(state='disabled')
-        continuous_response_button.configure(state='disabled')
         read_response_now_button.configure(state='disabled')
         summarize_button.configure(state='disabled')
+
+        # Add tooltip for disabled buttons
+        ToolTip(continuous_response_button, msg="Add API Key in override.yaml to enable button",
+                delay=0.01, follow=True, parent_kwargs={"padx": 3, "pady": 3},
+                padx=7, pady=7)
+        ToolTip(response_now_button, msg="Add API Key in override.yaml to enable button",
+                delay=0.01, follow=True, parent_kwargs={"padx": 3, "pady": 3},
+                padx=7, pady=7)
+        ToolTip(read_response_now_button, msg="Add API Key in override.yaml to enable button",
+                delay=0.01, follow=True, parent_kwargs={"padx": 3, "pady": 3},
+                padx=7, pady=7)
+        ToolTip(summarize_button, msg="Add API Key in override.yaml to enable button",
+                delay=0.01, follow=True, parent_kwargs={"padx": 3, "pady": 3},
+                padx=7, pady=7)
 
     def show_context_menu(event):
         try:


### PR DESCRIPTION
UX improvement. 
Add tooltips for disabled buttons to make it easier to realize why functionality is disabled.
Resolves #205 