### PR TITLE
OpenAI gpt-4o readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ or Deepgram
 or Together ($25 free Credits)
 oa Azure
 
-OpenAI gpt-4 model provides the best response generation capabilities. Earlier models work ok, but can sometimes provide inaccurate answers if there is not enough conversation content at the beginning.
+OpenAI gpt-4o model provides the best response generation capabilities. Earlier models work ok, but can sometimes provide inaccurate answers if there is not enough conversation content at the beginning.
 Together provides a large selection of [Inference models](https://docs.together.ai/docs/inference-models). Any of these can be used by making changes to `override.yaml` file.
 
 When using OpenAI, without the OpenAI key, using continuous response or any action that requires interaction with the online LLM gives an error similar to below

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -2,13 +2,15 @@ OpenAI:
   api_key: 'API_KEY'
   base_url: 'https://api.openai.com/v1'
 # Possible model values
+# gpt-4o, gpt-4o-2024-05-13
+# gpt-4-turbo, gpt-4-turbo-2024-04-09, gpt-4, gpt-4-0613, gpt-4-32k, gpt-4-32k-0613
 # gpt-3.5-turbo, gpt-3.5-turbo-16k, gpt-3.5-turbo-0613, gpt-3.5-turbo-16k-0613
-# gpt-4, gpt-4-0613, gpt-4-32k, gpt-4-32k-0613
+# 
 # Legacy models
 # text-davinci-003, text-davinci-002, code-davinci-002
 # See this link for available models
 # https://platform.openai.com/docs/models/continuous-model-upgrades
-  ai_model: gpt-4
+  ai_model: gpt-4o
 # Local model file to use for transcription.
 # Can also be specified using the -m parameter on command line of the application
   local_transcripton_model_file: 'base'

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -15,6 +15,6 @@ OpenAI:
 ```
 
 Default `base_url` for OpenAI is `https://api.openai.com/v1`
-Default `ai_model` for OpenAI is `gpt-4`
+Default `ai_model` for OpenAI is `gpt-4o`
 
 Our users have found this to be very useful in countries like Australia and China, where they cannot access the default providers directly or it is cost prohibitive to access these providers.


### PR DESCRIPTION
Default model now is gpt4o.
Doc updates.
All functionality should work with gpt4o.