### PR TITLE
Clarify Language Selection in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Transcribe provides real time transcription for microphone and speaker output. I
 ## Why Transcribe over other Speech to Text apps ##
 - Use Most of the functionality for **FREE**
 - Multi Lingual support
-- Choose between GPT 4.0, 3.5 or other inference models from OpenAI, or a plethora of inference models from [Together](https://docs.together.ai/docs/inference-models)
+- Choose between GPT 4o, 4, 3.5 or other inference models from OpenAI, or a plethora of inference models from [Together](https://docs.together.ai/docs/inference-models)
 - Streaming fast LLM responses instead of waiting for a complete response
 - Upto date with the latest OpenAI libraries
 - Get LLM responses for selected text

--- a/app/transcribe/app_utils.py
+++ b/app/transcribe/app_utils.py
@@ -1,3 +1,5 @@
+"""Utility methods to support main.py file
+"""
 import sys
 import subprocess  # nosec
 import threading
@@ -109,6 +111,8 @@ def start_ffmpeg():
 
 
 def initiate_db(global_vars: TranscriptionGlobals):
+    """Set up DB for use by application.
+    """
     # Create the DB if it does not exist and then init connections to it
     adb = AppDB()
     adb.initialize_db(db_context=global_vars.db_context)
@@ -186,6 +190,8 @@ def create_transcriber(
 
 
 def shutdown(global_vars: TranscriptionGlobals):
+    """Activities to be performed right before application shutdown.
+    """
     global_vars.user_audio_recorder.write_wav_data_to_file()
     global_vars.speaker_audio_recorder.write_wav_data_to_file()
     AppDB().shutdown_app()

--- a/app/transcribe/audio_transcriber.py
+++ b/app/transcribe/audio_transcriber.py
@@ -1,3 +1,5 @@
+"""Encapsulates all Speech to Text functionality
+"""
 import sys
 import os
 import subprocess  # nosec
@@ -12,9 +14,9 @@ import wave
 import tempfile
 import pyaudiowpatch as pyaudio
 # from db import AppDB as appdb
-sys.path.append('../..')
 import conversation  # noqa: E402 pylint: disable=C0413
 import constants  # noqa: E402 pylint: disable=C0413
+sys.path.append('../..')
 import custom_speech_recognition as sr  # noqa: E402 pylint: disable=C0413
 from tsutils import app_logging as al  # noqa: E402 pylint: disable=C0413
 from tsutils import duration  # noqa: E402 pylint: disable=C0413
@@ -93,6 +95,8 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
         self.conversation = convo
 
     def set_source_properties(self, mic_source=None, speaker_source=None):
+        """Resets the audio source properties stored in internal data structures.
+        """
         if mic_source is not None:
             self.audio_sources_properties['You']['sample_rate'] = mic_source.SAMPLE_RATE
             self.audio_sources_properties['You']['sample_width'] = mic_source.SAMPLE_WIDTH
@@ -191,7 +195,8 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
         in format of results. It is implemented in each transcriber specific class.
         """
 
-    def write_wav_data_to_file(self, data, channels, sample_width, frame_rate, file_path='', ) -> str:
+    def write_wav_data_to_file(self, data, channels,
+                               sample_width, frame_rate, file_path='', ) -> str:
         """Write the data as a wave file
         """
         if file_path == '':
@@ -443,8 +448,9 @@ class WhisperTranscriber(AudioTranscriber):
         # print(f'Segments: {len_segments}. Speech length: {len_speech} seconds.')
 
         if len_segments > WHISPER_SEGMENT_PRUNE_THRESHOLD:
-            # print(f'Attempt Prune segments: {len_segments - WHISPER_SEGMENT_PRUNE_THRESHOLD}.')
-            root_logger.info(f'Attempt Prune segments: {len_segments - WHISPER_SEGMENT_PRUNE_THRESHOLD}.')
+            log_msg = f'Attempt Prune segments: {len_segments - WHISPER_SEGMENT_PRUNE_THRESHOLD}.'
+            # print(log_msg)
+            root_logger.info(log_msg)
         else:
             # print(f'Segments: {len_segments}. Skip pruning.')
             return (False, 0, 0)
@@ -474,7 +480,8 @@ class WhisperTranscriber(AudioTranscriber):
 
         if prune_percent == 0:
             root_logger.info(f'Total segments ({len_segments}) is more than prune threshold'
-                             f' ({WHISPER_SEGMENT_PRUNE_THRESHOLD}), but could not find segment endings.')
+                             f' ({WHISPER_SEGMENT_PRUNE_THRESHOLD}), but could not find'
+                             f' segment endings.')
 
             # Attempt to determine prune percent based on audio duration
             if original_duration > AUDIO_LENGTH_PRUNE_THRESHOLD_SECONDS:
@@ -631,8 +638,9 @@ class WhisperCPPTranscriber(AudioTranscriber):
         # print(f'Segments: {len_segments}. Speech length: {len_speech_ms} milliseconds.')
 
         if len_segments > WHISPERCPP_SEGMENT_PRUNE_THRESHOLD:
-            # print(f'Attempt Prune segments: {len_segments - WHISPERCPP_SEGMENT_PRUNE_THRESHOLD}.')
-            root_logger.info(f'Attempt Prune segments: {len_segments - WHISPERCPP_SEGMENT_PRUNE_THRESHOLD}.')
+            log_msg = f'Attempt Prune segments: {len_segments-WHISPERCPP_SEGMENT_PRUNE_THRESHOLD}.'
+            # print(log_msg)
+            root_logger.info(log_msg)
         else:
             # print(f'Segments: {len_segments}. Skip pruning.')
             return (False, 0, 0)
@@ -659,7 +667,8 @@ class WhisperCPPTranscriber(AudioTranscriber):
 
         if prune_percent == 0:
             root_logger.info(f'Total segments ({len_segments}) is more than prune threshold'
-                             f' ({WHISPERCPP_SEGMENT_PRUNE_THRESHOLD}), but could not find segment endings.')
+                             f' ({WHISPERCPP_SEGMENT_PRUNE_THRESHOLD}), but could not find'
+                             f' segment endings.')
 
             segment_id = 0
             # Attempt to determine prune percent based on audio duration
@@ -800,7 +809,8 @@ class DeepgramTranscriber(AudioTranscriber):
         # First paragraph we will keep is
         beginning_para = para_list[-DEEPGRAM_PARAGRAPH_PRUNE_THRESHOLD]
         start_time = float(beginning_para.sentences[0].start)
-        # print(f"First para to keep, start time: {start_time}. Para text: {beginning_para['sentences'][0]['text']}.")
+        # print(f"First para to keep, start time: {start_time}.")
+        # print(f"Para text: {beginning_para['sentences'][0]['text']}.")
         prune_percent = start_time / speech_duration
 
         # Incorporate AUDIO_LENGTH_PRUNE_THRESHOLD_SECONDS into pruning calculations

--- a/app/transcribe/conversation.py
+++ b/app/transcribe/conversation.py
@@ -26,6 +26,10 @@ class Conversation:
         """
         self.config = configuration.Config().data
         prompt = self.config["General"]["system_prompt"]
+        response_lang = self.config["OpenAI"]["response_lang"]
+        if response_lang is not None:
+            prompt += f'.  Respond exclusively in {response_lang}.'
+
         self.update_conversation(persona=constants.PERSONA_SYSTEM, text=prompt,
                                  time_spoken=datetime.datetime.utcnow())
         initial_convo: dict = self.config["General"]["initial_convo"]

--- a/app/transcribe/db/app_db.py
+++ b/app/transcribe/db/app_db.py
@@ -56,7 +56,7 @@ class AppDB(Singleton.Singleton):
 
         # Initialize DB logger
         db_log_file_name = f'{self._db_context["db_log_file"]}'
-        db_handler = logging.FileHandler(db_log_file_name)
+        db_handler = logging.FileHandler(db_log_file_name, encoding='utf-8')
         db_logger = logging.getLogger('sqlalchemy')
         db_handler_log_level = logging.INFO
         db_logger_log_level = logging.DEBUG

--- a/app/transcribe/db/conversation.py
+++ b/app/transcribe/db/conversation.py
@@ -80,6 +80,9 @@ class Conversations:
                 rows = result.fetchall()
                 convo_id = rows[0][0]
 
+                if convo_id is None:
+                    return
+
                 # Update the row
                 query = text(f'UPDATE Conversations SET Text = "{convo_text}" WHERE Id = {convo_id}')
                 session.execute(query)

--- a/app/transcribe/db/conversation.py
+++ b/app/transcribe/db/conversation.py
@@ -3,7 +3,6 @@ from sqlalchemy import Column, Integer, String, DateTime
 from sqlalchemy.sql import text
 from sqlalchemy.orm import Session, mapped_column
 from sqlalchemy import Engine, insert
-# from db import DB_CONTEXT
 
 TABLE_NAME = 'Conversations'
 
@@ -19,7 +18,8 @@ class Conversation():
     Text = mapped_column(String, nullable=False)
 
     def __repr__(self) -> str:
-        return f"Invocation(id={self.Id!r}, SpokenTime={self.SpokenTime!r}, Speaker={self.Speaker!r}, Text={self.Text!r})"
+        return f"Invocation(id={self.Id!r}, SpokenTime={self.SpokenTime!r}," \
+               f"Speaker={self.Speaker!r}, Text={self.Text!r})"
 
 
 class Conversations:
@@ -45,7 +45,8 @@ class Conversations:
         """Create conversation table in DB.
         """
         self._db_table = sqldb.Table(self._table_name, metadata,
-                                     Column('Id', Integer(), sqldb.Identity(start=1), primary_key=True),
+                                     Column('Id', Integer(), sqldb.Identity(start=1),
+                                            primary_key=True),
                                      Column("InvocationId", Integer, nullable=False),
                                      Column('SpokenTime', sqldb.Integer(), nullable=False),
                                      Column('Speaker', String(40), nullable=False),
@@ -75,7 +76,9 @@ class Conversations:
         try:
             with Session(engine) as session:
                 # Get row id we need to update
-                query = text(f'SELECT MAX(Id) from Conversations where InvocationId = {invocation_id}')
+                query = text(f'SELECT MAX(Id) '
+                             f'FROM Conversations '
+                             f'WHERE InvocationId = {invocation_id}')
                 result = session.execute(query)
                 rows = result.fetchall()
                 convo_id = rows[0][0]
@@ -84,7 +87,9 @@ class Conversations:
                     return
 
                 # Update the row
-                query = text(f'UPDATE Conversations SET Text = "{convo_text}" WHERE Id = {convo_id}')
+                query = text(f'UPDATE Conversations '
+                             f'SET Text = "{convo_text}" '
+                             f'WHERE Id = {convo_id}')
                 session.execute(query)
                 session.commit()
                 session.close()
@@ -92,4 +97,6 @@ class Conversations:
             print(ex)
 
     def populate_data(self):
-        pass
+        """Not Implemented
+        """
+        pass   # pylint: disable=W0107

--- a/app/transcribe/global_vars.py
+++ b/app/transcribe/global_vars.py
@@ -1,3 +1,5 @@
+"""Global context for the application
+"""
 import sys
 import os
 import queue
@@ -78,6 +80,8 @@ class TranscriptionGlobals(Singleton.Singleton):
         self._initialized = True
 
     def set_transcriber(self, transcriber):
+        """Set Transcriber to be used across the application.
+        """
         self.transcriber = transcriber
 
     def initiate_audio_devices(self, config: dict):
@@ -95,7 +99,8 @@ class TranscriptionGlobals(Singleton.Singleton):
         self.speaker_audio_recorder = ar.SpeakerRecorder(audio_file_name='speaker.wav')
         if not config['General']['disable_speaker'] and config['General']['speaker_device_index'] != -1:
             print('[INFO] Override default speaker with device specified in parameters file.')
-            self.speaker_audio_recorder.set_device(index=int(config['General']['speaker_device_index']))
+            self.speaker_audio_recorder.set_device(index=int(
+                config['General']['speaker_device_index']))
 
     def set_read_response(self, value: bool):
         """Signal that the response will be read aloud

--- a/app/transcribe/gpt_responder.py
+++ b/app/transcribe/gpt_responder.py
@@ -36,7 +36,7 @@ class GPTResponder:
         root_logger.info(GPTResponder.__name__)
         # This var is used by UI to populate the response textbox
         self.response = prompts.INITIAL_RESPONSE
-        self.response_interval = 2
+        self.llm_response_interval = 2
         self.conversation = convo
         self.config = config
         self.save_response_to_file = save_to_file
@@ -278,17 +278,17 @@ class GPTResponder:
                 end_time = time.time()  # Measure end time
                 execution_time = end_time - start_time  # Calculate time to execute the function
 
-                remaining_time = self.response_interval - execution_time
+                remaining_time = self.llm_response_interval - execution_time
                 if remaining_time > 0:
                     time.sleep(remaining_time)
             else:
-                time.sleep(self.response_interval)
+                time.sleep(self.llm_response_interval)
 
     def update_response_interval(self, interval):
         """Change the interval for pinging LLM
         """
         root_logger.info(GPTResponder.update_response_interval.__name__)
-        self.response_interval = interval
+        self.llm_response_interval = interval
 
     def _pretty_print_openai_request(self, message: str):
         """Format the openAI request in a nice print format"""

--- a/app/transcribe/main.py
+++ b/app/transcribe/main.py
@@ -70,14 +70,15 @@ def main():
     update_interval_slider = ui_components[2]
     global_vars.update_interval_slider_label = ui_components[3]
     global_vars.freeze_button = ui_components[4]
-    lang_combobox = ui_components[5]
-    global_vars.filemenu = ui_components[6]
-    response_now_button = ui_components[7]
-    read_response_now_button = ui_components[8]
-    global_vars.editmenu = ui_components[9]
-    github_link = ui_components[10]
-    issue_link = ui_components[11]
-    summarize_button = ui_components[12]
+    audio_lang_combobox = ui_components[5]
+    response_lang_combobox = ui_components[6]
+    global_vars.filemenu = ui_components[7]
+    response_now_button = ui_components[8]
+    read_response_now_button = ui_components[9]
+    global_vars.editmenu = ui_components[10]
+    github_link = ui_components[11]
+    issue_link = ui_components[12]
+    summarize_button = ui_components[13]
 
     # disable speaker/microphone on startup
     if config['General']['disable_speaker']:
@@ -106,7 +107,8 @@ def main():
     update_interval_slider.configure(command=ui_cb.update_interval_slider_label)
     label_text = f'LLM Response interval: {int(update_interval_slider.get())} seconds'
     global_vars.update_interval_slider_label.configure(text=label_text)
-    lang_combobox.configure(command=global_vars.transcriber.stt_model.set_lang)
+    audio_lang_combobox.configure(command=ui_cb.set_audio_language)
+    response_lang_combobox.configure(command=ui_cb.set_response_language)
     global_vars.transcriber.stt_model.set_lang(config['OpenAI']['audio_lang'])
     github_link.bind('<Button-1>', lambda e:
                      ui_cb.open_link('https://github.com/vivekuppal/transcribe?referer=desktop'))

--- a/app/transcribe/main.py
+++ b/app/transcribe/main.py
@@ -107,6 +107,7 @@ def main():
     label_text = f'LLM Response interval: {int(update_interval_slider.get())} seconds'
     global_vars.update_interval_slider_label.configure(text=label_text)
     lang_combobox.configure(command=global_vars.transcriber.stt_model.set_lang)
+    global_vars.transcriber.stt_model.set_lang(config['OpenAI']['audio_lang'])
     github_link.bind('<Button-1>', lambda e:
                      ui_cb.open_link('https://github.com/vivekuppal/transcribe?referer=desktop'))
     issue_link.bind('<Button-1>', lambda e: ui_cb.open_link(

--- a/app/transcribe/main.py
+++ b/app/transcribe/main.py
@@ -109,6 +109,7 @@ def main():
     global_vars.update_interval_slider_label.configure(text=label_text)
     audio_lang_combobox.configure(command=ui_cb.set_audio_language)
     response_lang_combobox.configure(command=ui_cb.set_response_language)
+    # Set the response lang in STT Model.
     global_vars.transcriber.stt_model.set_lang(config['OpenAI']['audio_lang'])
     github_link.bind('<Button-1>', lambda e:
                      ui_cb.open_link('https://github.com/vivekuppal/transcribe?referer=desktop'))

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -18,6 +18,8 @@ OpenAI:
 # List of languages available for openAI is available at
 # https://platform.openai.com/docs/guides/speech-to-text/supported-languages
   response_lang: English
+# Interpret the audio from speakers, mic to be in this language
+  audio_lang: English
 
 # Request timeout for any response requests made to openAI API
   response_request_timeout_seconds: 10
@@ -77,7 +79,7 @@ General:
   stt: whisper
   continuous_response: True
   # The interval at which to ping the LLM for response
-  response_interval: 10
+  llm_response_interval: 10
 
 # This is equivalent to -c argument on command line
 # Command line argument takes precedence over value specified in parameters.yaml

--- a/app/transcribe/prompts.py
+++ b/app/transcribe/prompts.py
@@ -19,6 +19,9 @@ def create_prompt_for_text(text: str, config: dict):
     complete_prompt = f'{config["General"]["default_prompt_preamble"]} '\
         f'{text}'\
         f'{config["General"]["default_prompt_epilogue"]}'
+    response_lang = config["OpenAI"]["response_lang"]
+    if response_lang is not None:
+        complete_prompt += f'.  Respond exclusively in {response_lang}.'
     messages = [{"role": "system", "content": complete_prompt}]
     return messages
 

--- a/app/transcribe/requirements.txt
+++ b/app/transcribe/requirements.txt
@@ -1,7 +1,7 @@
 numpy==1.26.4
 openai-whisper==20231117
 Wave==0.0.2
-openai==1.25.0
+openai==1.30.1
 customtkinter==5.2.2
 tkinter-tooltip  # Needed to show tooltips for ctk components
 PyAudioWPatch==0.2.12.6

--- a/app/transcribe/ui.py
+++ b/app/transcribe/ui.py
@@ -47,7 +47,8 @@ class UICallbacks:
            Does not include responses from assistant.
         """
         root_logger.info(UICallbacks.save_file.__name__)
-        filename = ctk.filedialog.asksaveasfilename(defaultextension='.txt', title='Save Transcription',
+        filename = ctk.filedialog.asksaveasfilename(defaultextension='.txt',
+                                                    title='Save Transcription',
                                                     filetypes=[("Text Files", "*.txt")])
         self.capture_action(f'Save transcript to file:{filename}')
         if filename == '':
@@ -170,7 +171,8 @@ class UICallbacks:
 
             pop_up = None
         if summary is None:
-            popup_msg_close_button(title='Summary', msg='Failed to get summary. Please check you have a valid API key.')
+            popup_msg_close_button(title='Summary',
+                                   msg='Failed to get summary. Please check you have a valid API key.')
             return
         # Enhancement here would be to get a streaming summary
         popup_msg_close_button(title='Summary', msg=summary)
@@ -257,11 +259,6 @@ class UICallbacks:
                                   text=prompt,
                                   time_spoken=datetime.datetime.utcnow(),
                                   update_previous=True)
-
-    # def response_for_selected_text(self):
-    #     """Get response from LLM for selected text"""
-    #     selected_text = self.global_vars.transcript_textbox.selection_get()
-    #     print(selected_text)
 
 
 def popup_msg_no_close_threaded(title, msg):
@@ -457,10 +454,12 @@ def create_ui_components(root, config: dict):
     # Add the menu bar to the main window
     root.config(menu=menubar)
 
+    # Speech to Text textbox
     transcript_textbox = ctk.CTkTextbox(root, width=300, font=("Arial", UI_FONT_SIZE),
                                         text_color='#FFFCF2', wrap="word")
     transcript_textbox.grid(row=0, column=0, columnspan=2, padx=10, pady=3, sticky="nsew")
 
+    # LLM Response textbox
     response_textbox = ctk.CTkTextbox(root, width=300, font=("Arial", UI_FONT_SIZE),
                                       text_color='#639cdc', wrap="word")
     response_textbox.grid(row=0, column=2, padx=10, pady=3, sticky="nsew")
@@ -480,6 +479,7 @@ def create_ui_components(root, config: dict):
     summarize_button = ctk.CTkButton(root, text="Summarize")
     summarize_button.grid(row=4, column=2, padx=10, pady=3, sticky="nsew")
 
+    # Continuous LLM Response label, and slider
     update_interval_slider_label = ctk.CTkLabel(root, text="", font=("Arial", 12),
                                                 text_color="#FFFCF2")
     update_interval_slider_label.grid(row=1, column=0, columnspan=2, padx=10, pady=3, sticky="nsew")
@@ -489,7 +489,10 @@ def create_ui_components(root, config: dict):
     update_interval_slider.set(config['General']['llm_response_interval'])
     update_interval_slider.grid(row=2, column=0, columnspan=2, padx=10, pady=3, sticky="nsew")
 
-    audio_lang_label = ctk.CTkLabel(root, text="Audio Lang: ", font=("Arial", 12), text_color="#FFFCF2")
+    # Speech to text language selection label, dropdown
+    audio_lang_label = ctk.CTkLabel(root, text="Audio Lang: ",
+                                    font=("Arial", 12),
+                                    text_color="#FFFCF2")
     audio_lang_label.grid(row=3, column=0, padx=10, pady=3, sticky="nw")
 
     audio_lang = config['OpenAI']['audio_lang']
@@ -497,7 +500,10 @@ def create_ui_components(root, config: dict):
     audio_lang_combobox.set(audio_lang)
     audio_lang_combobox.grid(row=3, column=0, ipadx=60, padx=10, pady=3, sticky="ne")
 
-    response_lang_label = ctk.CTkLabel(root, text="Response Lang: ", font=("Arial", 12), text_color="#FFFCF2")
+    # LLM Response language selection label, dropdown
+    response_lang_label = ctk.CTkLabel(root,
+                                       text="Response Lang: ",
+                                       font=("Arial", 12), text_color="#FFFCF2")
     response_lang_label.grid(row=3, column=1, padx=10, pady=3, sticky="nw")
 
     response_lang = config['OpenAI']['response_lang']
@@ -512,7 +518,8 @@ def create_ui_components(root, config: dict):
     issue_link = ctk.CTkLabel(root, text="Report an issue", text_color="#639cdc", cursor="hand2")
     issue_link.grid(row=4, column=1, padx=10, pady=3, sticky="wn")
 
-    # Create right click menu for transcript textbox
+    # Create right click menu for transcript textbox.
+    # This displays only inside the speech to text textbox
     m = tk.Menu(root, tearoff=0)
     m.add_command(label="Generate response for selected text",
                   command=ui_cb.get_response_selected_now)
@@ -541,7 +548,7 @@ def create_ui_components(root, config: dict):
         summarize_button.configure(state='disabled')
 
         tt_msg = 'Add API Key in override.yaml to enable button'
-        # Add tooltip for disabled buttons
+        # Add tooltips for disabled buttons
         ToolTip(continuous_response_button, msg=tt_msg,
                 delay=0.01, follow=True, parent_kwargs={"padx": 3, "pady": 3},
                 padx=7, pady=7)

--- a/app/transcribe/ui.py
+++ b/app/transcribe/ui.py
@@ -444,17 +444,10 @@ def create_ui_components(root, config: dict):
     # Add "Disable Microphone" menu item to file menu
     editmenu.add_command(label="Disable Microphone", command=lambda: ui_cb.enable_disable_microphone(editmenu))
 
-    # See example of add_radiobutton() at https://www.plus2net.com/python/tkinter-menu.php
-    # Radiobutton would be a good way to display different languages
-    # lang_menu = tk.Menu(menubar, tearoff=False)
-    # for lang in LANGUAGES_DICT.values():
-    #    model.change_lang
-    #    lang_menu.add_command(label=lang, command=model.change_lang)
-    # editmenu.add_cascade(menu=lang_menu, label='Languages')
-
     # Add the edit menu to the menu bar
     menubar.add_cascade(label="Edit", menu=editmenu)
 
+    # Create help menu, add items in help menu
     helpmenu = tk.Menu(menubar, tearoff=False)
     helpmenu.add_command(label="Github Repo", command=ui_cb.open_github)
     helpmenu.add_command(label="Star the Github repo", command=ui_cb.open_github)
@@ -466,35 +459,35 @@ def create_ui_components(root, config: dict):
 
     transcript_textbox = ctk.CTkTextbox(root, width=300, font=("Arial", UI_FONT_SIZE),
                                         text_color='#FFFCF2', wrap="word")
-    transcript_textbox.grid(row=0, column=0, columnspan=2, padx=10, pady=20, sticky="nsew")
+    transcript_textbox.grid(row=0, column=0, columnspan=2, padx=10, pady=3, sticky="nsew")
 
     response_textbox = ctk.CTkTextbox(root, width=300, font=("Arial", UI_FONT_SIZE),
                                       text_color='#639cdc', wrap="word")
-    response_textbox.grid(row=0, column=2, padx=10, pady=20, sticky="nsew")
+    response_textbox.grid(row=0, column=2, padx=10, pady=3, sticky="nsew")
     response_textbox.insert("0.0", prompts.INITIAL_RESPONSE)
 
     response_enabled = bool(config['General']['continuous_response'])
     b_text = "Suggest Responses Continuously" if not response_enabled else "Do Not Suggest Responses Continuously"
-    continuous_response_button = ctk.CTkButton(root, text=b_text, command=None)
+    continuous_response_button = ctk.CTkButton(root, text=b_text)
     continuous_response_button.grid(row=1, column=2, padx=10, pady=3, sticky="nsew")
 
-    response_now_button = ctk.CTkButton(root, text="Suggest Response Now", command=None)
+    response_now_button = ctk.CTkButton(root, text="Suggest Response Now")
     response_now_button.grid(row=2, column=2, padx=10, pady=3, sticky="nsew")
 
-    read_response_now_button = ctk.CTkButton(root, text="Suggest Response and Read", command=None)
+    read_response_now_button = ctk.CTkButton(root, text="Suggest Response and Read")
     read_response_now_button.grid(row=3, column=2, padx=10, pady=3, sticky="nsew")
 
-    summarize_button = ctk.CTkButton(root, text="Summarize", command=None)
+    summarize_button = ctk.CTkButton(root, text="Summarize")
     summarize_button.grid(row=4, column=2, padx=10, pady=3, sticky="nsew")
 
     update_interval_slider_label = ctk.CTkLabel(root, text="", font=("Arial", 12),
                                                 text_color="#FFFCF2")
     update_interval_slider_label.grid(row=1, column=0, columnspan=2, padx=10, pady=3, sticky="nsew")
 
-    update_interval_slider = ctk.CTkSlider(root, from_=1, to=30, width=300, height=20,
-                                           number_of_steps=9)
+    update_interval_slider = ctk.CTkSlider(root, from_=1, to=30, width=300,  # height=5,
+                                           number_of_steps=29)
     update_interval_slider.set(config['General']['llm_response_interval'])
-    update_interval_slider.grid(row=2, column=0, columnspan=2, padx=10, pady=10, sticky="nsew")
+    update_interval_slider.grid(row=2, column=0, columnspan=2, padx=10, pady=3, sticky="nsew")
 
     audio_lang_label = ctk.CTkLabel(root, text="Audio Lang: ", font=("Arial", 12), text_color="#FFFCF2")
     audio_lang_label.grid(row=3, column=0, padx=10, pady=3, sticky="nw")
@@ -502,7 +495,7 @@ def create_ui_components(root, config: dict):
     audio_lang = config['OpenAI']['audio_lang']
     audio_lang_combobox = ctk.CTkOptionMenu(root, width=15, values=list(LANGUAGES_DICT.values()))
     audio_lang_combobox.set(audio_lang)
-    audio_lang_combobox.grid(row=3, column=0, ipadx=60, padx=10, sticky="ne")
+    audio_lang_combobox.grid(row=3, column=0, ipadx=60, padx=10, pady=3, sticky="ne")
 
     response_lang_label = ctk.CTkLabel(root, text="Response Lang: ", font=("Arial", 12), text_color="#FFFCF2")
     response_lang_label.grid(row=3, column=1, padx=10, pady=3, sticky="nw")
@@ -510,14 +503,14 @@ def create_ui_components(root, config: dict):
     response_lang = config['OpenAI']['response_lang']
     response_lang_combobox = ctk.CTkOptionMenu(root, width=15, values=list(LANGUAGES_DICT.values()))
     response_lang_combobox.set(response_lang)
-    response_lang_combobox.grid(row=3, column=1, ipadx=60, padx=10, sticky="ne")
+    response_lang_combobox.grid(row=3, column=1, ipadx=60, padx=10, pady=3, sticky="ne")
 
     github_link = ctk.CTkLabel(root, text="Star the Github Repo",
                                text_color="#639cdc", cursor="hand2")
-    github_link.grid(row=4, column=0, columnspan=2, padx=10, pady=10, sticky="wn")
+    github_link.grid(row=4, column=0, padx=10, pady=3, sticky="wn")
 
     issue_link = ctk.CTkLabel(root, text="Report an issue", text_color="#639cdc", cursor="hand2")
-    issue_link.grid(row=4, column=1, columnspan=2, padx=10, pady=10, sticky="nw")
+    issue_link.grid(row=4, column=1, padx=10, pady=3, sticky="wn")
 
     # Create right click menu for transcript textbox
     m = tk.Menu(root, tearoff=0)
@@ -573,6 +566,6 @@ def create_ui_components(root, config: dict):
     # Order of returned components is important.
     # Add new components to the end
     return [transcript_textbox, response_textbox, update_interval_slider,
-            update_interval_slider_label, continuous_response_button, audio_lang_combobox,
-            response_lang_combobox, filemenu, response_now_button, read_response_now_button, editmenu,
-            github_link, issue_link, summarize_button]
+            update_interval_slider_label, continuous_response_button,
+            audio_lang_combobox, response_lang_combobox, filemenu, response_now_button,
+            read_response_now_button, editmenu, github_link, issue_link, summarize_button]

--- a/app/transcribe/ui.py
+++ b/app/transcribe/ui.py
@@ -461,20 +461,25 @@ def create_ui_components(root, config: dict):
                                                 text_color="#FFFCF2")
     update_interval_slider_label.grid(row=1, column=0, padx=10, pady=3, sticky="nsew")
 
-    update_interval_slider = ctk.CTkSlider(root, from_=1, to=10, width=300, height=20,
+    update_interval_slider = ctk.CTkSlider(root, from_=1, to=30, width=300, height=20,
                                            number_of_steps=9)
-    update_interval_slider.set(config['General']['response_interval'])
+    update_interval_slider.set(config['General']['llm_response_interval'])
     update_interval_slider.grid(row=2, column=0, padx=10, pady=10, sticky="nsew")
 
+    audio_lang_label = ctk.CTkLabel(root, text="Audio Lang: ", font=("Arial", 12), text_color="#FFFCF2")
+    audio_lang_label.grid(row=3, column=0, padx=10, pady=3, sticky="wn")
+
+    audio_lang = config['OpenAI']['audio_lang']
     lang_combobox = ctk.CTkOptionMenu(root, width=15, values=list(LANGUAGES_DICT.values()))
-    lang_combobox.grid(row=3, column=0, ipadx=60, padx=10, sticky="wn")
+    lang_combobox.set(audio_lang)
+    lang_combobox.grid(row=3, column=0, ipadx=60, padx=10, sticky="n")
 
     github_link = ctk.CTkLabel(root, text="Star the Github Repo",
                                text_color="#639cdc", cursor="hand2")
-    github_link.grid(row=3, column=0, padx=10, pady=10, sticky="n")
+    github_link.grid(row=4, column=0, padx=10, pady=10, sticky="wn")
 
     issue_link = ctk.CTkLabel(root, text="Report an issue", text_color="#639cdc", cursor="hand2")
-    issue_link.grid(row=3, column=0, padx=10, pady=10, sticky="en")
+    issue_link.grid(row=4, column=0, padx=10, pady=10, sticky="n")
 
     # Create right click menu for transcript textbox
     m = tk.Menu(root, tearoff=0)

--- a/sdk/transcriber_models.py
+++ b/sdk/transcriber_models.py
@@ -59,20 +59,20 @@ class STTModelInterface:
     def get_transcription(self, wav_file_path: str):
         """Get transcription from the provided audio file
         """
-        pass
+        pass  # pylint: disable=W0107
 
     @abstractmethod
     def get_sentences(self, wav_file_path: str):
         """Get transcription from the provided audio file
            as individual sentences
         """
-        pass
+        pass  # pylint: disable=W0107
 
     @abstractmethod
     def process_response(self, response) -> str:
         """Extract transcription from the response of the specific STT Model
         """
-        pass
+        pass  # pylint: disable=W0107
 
 
 class WhisperSTTModel(STTModelInterface):
@@ -322,6 +322,11 @@ class WhisperCPPSTTModel(STTModelInterface):
             text += segment["text"]
         # print(f'Transcript: {text}')
         return text
+
+    def get_sentences(self, wav_file_path: str):
+        """Not Implemented
+        """
+        raise Exception('Method not implemnted')  # pylint: disable=W0719
 
 
 class DeepgramSTTModel(STTModelInterface):


### PR DESCRIPTION
- Distinguish between the two language selections for STT and LLM Response.
- Audio can be in one language and responses can be in a different language.
- Remember both language settings across application restart.
- Enable utf-8 logging in db.log.
- Allow LLM response interval to be configurable up to 30s in UI.

Resolves issue #52 
