### PR TITLE
Add experimental SenseVoiceSmall transcription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Connect on LinkedIn to discuss further.
 - [Speech Mode](./docs/SpeechMode.md)
 - [Save Content](./docs/SaveContent.md)
 - [Model Selection](./docs/ModelSelection.md)
+- [Experimental SenseVoiceSmall backend](./docs/SenseVoice.md)
 - [Batch Operations](./docs/BatchOperations.md)
 - [Application Configuration](./docs/AppConfig.md)
 - [OpenAI API Compatible Provider Support](./docs/Providers.md)

--- a/app/transcribe/cli/arguments.py
+++ b/app/transcribe/cli/arguments.py
@@ -27,7 +27,7 @@ def create_args() -> argparse.Namespace:
         "--speech_to_text",
         action="store",
         default=None,
-        choices=["whisper", "whisper.cpp", "deepgram"],
+        choices=["whisper", "whisper.cpp", "deepgram", "sensevoice"],
         help="Specify the Speech to text Engine.\nLocal STT models tend to perform best for response times.\nAPI based STT models tend to perform best for accuracy.",
     )
     cmd_args.add_argument(

--- a/app/transcribe/db/app_db.py
+++ b/app/transcribe/db/app_db.py
@@ -61,13 +61,23 @@ class AppDB(Singleton.Singleton):
 
         # Initialize DB logger
         db_log_file_name = f'{self._db_context["db_log_file"]}'
-        db_handler = logging.FileHandler(db_log_file_name, encoding='utf-8')
         self._db_logger = logging.getLogger('sqlalchemy')
         db_handler_log_level = logging.INFO
-        db_logger_log_level = logging.DEBUG
-        db_handler.setLevel(db_handler_log_level)
-        self._db_logger.addHandler(db_handler)
+        db_logger_log_level = logging.INFO
+
+        db_log_path = str(db_log_file_name)
+        has_db_handler = any(
+            isinstance(handler, logging.FileHandler)
+            and handler.baseFilename == db_log_path
+            for handler in self._db_logger.handlers
+        )
+        if not has_db_handler:
+            db_handler = logging.FileHandler(db_log_file_name, encoding='utf-8')
+            db_handler.setLevel(db_handler_log_level)
+            self._db_logger.addHandler(db_handler)
+
         self._db_logger.setLevel(db_logger_log_level)
+        self._db_logger.propagate = False
 
         # Initialize all the tables
         self._tables[appi.TABLE_NAME] = appi.ApplicationInvocations(engine=self._engine)

--- a/app/transcribe/db/tests/test_app_db.py
+++ b/app/transcribe/db/tests/test_app_db.py
@@ -1,0 +1,56 @@
+"""Tests for application database logging configuration."""
+
+import logging
+import io
+import os
+import tempfile
+import unittest
+
+from sqlalchemy import text
+
+from app.transcribe.db.app_db import AppDB
+
+
+class TestAppDB(unittest.TestCase):
+    def test_sqlalchemy_logs_do_not_propagate_to_console(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_log_file = os.path.join(temp_dir, "db.log")
+            db_context = {
+                "db_file_path": os.path.join(temp_dir, "app.db"),
+                "db_log_file": db_log_file,
+            }
+            app_db = AppDB()
+            root_stream = io.StringIO()
+            root_handler = logging.StreamHandler(root_stream)
+            root_logger = logging.getLogger()
+            root_logger.addHandler(root_handler)
+
+            try:
+                app_db.initialize_db(db_context=db_context)
+
+                with app_db.get_engine().connect() as connection:
+                    connection.execute(text("SELECT 1"))
+
+                sqlalchemy_logger = logging.getLogger("sqlalchemy")
+                self.assertFalse(sqlalchemy_logger.propagate)
+                self.assertEqual(root_stream.getvalue(), "")
+
+                for handler in sqlalchemy_logger.handlers:
+                    handler.flush()
+                with open(db_log_file, encoding="utf-8") as log_file:
+                    self.assertIn("SELECT 1", log_file.read())
+            finally:
+                if app_db.get_engine() is not None:
+                    app_db.get_engine().dispose()
+                root_logger.removeHandler(root_handler)
+                root_handler.close()
+
+                sqlalchemy_logger = logging.getLogger("sqlalchemy")
+                for handler in list(sqlalchemy_logger.handlers):
+                    if isinstance(handler, logging.FileHandler) and handler.baseFilename == db_log_file:
+                        sqlalchemy_logger.removeHandler(handler)
+                        handler.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/transcribe/gpt_responder.py
+++ b/app/transcribe/gpt_responder.py
@@ -381,8 +381,7 @@ class OpenAIResponder(GPTResponder):
         base_url = self.config['OpenAI']['base_url']
         self.llm_client = openai.OpenAI(api_key=api_key, base_url=base_url)
         self.model = self.config['OpenAI']['ai_model']
-        stt = self.config['General']['stt']
-        print(f'[INFO] Using {stt} for inference. Model: {self.model}')
+        logger.info(f'Configured OpenAI response generation. Model: {self.model}')
         super().__init__(config=self.config,
                          convo=convo,
                          save_to_file=save_to_file,
@@ -404,7 +403,7 @@ class TogetherAIResponder(GPTResponder):
         self.llm_client = openai.OpenAI(api_key=api_key,
                                         base_url=base_url)
         self.model = self.config['Together']['ai_model']
-        print(f'[INFO] Using Together AI for inference. Model: {self.model}')
+        logger.info(f'Configured Together AI response generation. Model: {self.model}')
         super().__init__(config=self.config,
                          convo=convo,
                          save_to_file=save_to_file,

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -1,19 +1,10 @@
 OpenAI:
   api_key: 'API_KEY'
   base_url: 'https://api.openai.com/v1'
-# Possible model values
-# gpt-4o, gpt-4o-2024-05-13
-# gpt-4-turbo, gpt-4-turbo-2024-04-09, gpt-4, gpt-4-0613, gpt-4-32k, gpt-4-32k-0613
-# gpt-3.5-turbo, gpt-3.5-turbo-16k, gpt-3.5-turbo-0613, gpt-3.5-turbo-16k-0613
-# gpt-4o
-# Legacy models
-# text-davinci-003, text-davinci-002, code-davinci-002
-# See this link for available models
-# https://platform.openai.com/docs/models/continuous-model-upgrades
-# https://platform.openai.com/docs/models
-# We do not support o3-mini out of the box, because it does not support
-# some of the parameters for several API
-  ai_model: gpt-4o-mini
+# gpt-5.4-mini is the default price/performance option for general responses.
+# Use gpt-5.4-nano for simpler, lower-cost workloads, or gpt-5.4 for higher quality.
+# See https://developers.openai.com/api/docs/models
+  ai_model: gpt-5.4-mini
 # Local model file to use for transcription.
 # Can also be specified using the -m parameter on command line of the application
   local_transcripton_model_file: 'base'
@@ -45,6 +36,12 @@ Together:
 WhisperCpp:
   # Can also be specified using the -m parameter on command line of the application
   local_transcripton_model_file: 'base'
+
+SenseVoice:
+  # Experimental Windows-only backend. Run setup-sensevoice.bat first.
+  model: 'FunAudioLLM/SenseVoiceSmall'
+  device: 'auto'  # auto, cpu, or cuda:0
+  use_itn: True
 
 General:
   log_file: 'logs/Transcribe.log'

--- a/app/transcribe/providers/stt.py
+++ b/app/transcribe/providers/stt.py
@@ -100,6 +100,19 @@ def create_stt_model(name: str, config: dict, api: bool):
             stt_model_config=stt_model_config,
         )
 
+    if name.lower() == "sensevoice":
+        sensevoice_config = config.get("SenseVoice", {})
+        stt_model_config = {
+            "model": sensevoice_config.get("model", "FunAudioLLM/SenseVoiceSmall"),
+            "device": sensevoice_config.get("device", "auto"),
+            "use_itn": sensevoice_config.get("use_itn", True),
+            "audio_lang": get_language_code(config["OpenAI"]["audio_lang"]),
+        }
+        return model_factory.get_stt_model_instance(
+            stt_model=tm.STTEnum.SENSEVOICE_LOCAL,
+            stt_model_config=stt_model_config,
+        )
+
     if name.lower() == "whisper" and not api:
         stt_model_config = {
             "api_key": config["OpenAI"]["api_key"],

--- a/app/transcribe/requirements-sensevoice.txt
+++ b/app/transcribe/requirements-sensevoice.txt
@@ -1,0 +1,7 @@
+# Optional Windows-only dependencies for the experimental SenseVoiceSmall backend.
+# Install the base requirements first, then install this file.
+funasr==1.3.9
+modelscope==1.37.1
+transformers==4.51.3
+huggingface-hub==0.30.2
+click==8.1.8

--- a/app/transcribe/requirements.txt
+++ b/app/transcribe/requirements.txt
@@ -16,11 +16,8 @@ gtts
 # in case of continuous play back of files in quick succession
 playsound==1.2.2
 deepgram-sdk==3.2.5
-# Use 117 to build for CPU only
-# --extra-index-url https://download.pytorch.org/whl/cu117
-#--extra-index-url https://download.pytorch.org/whl/cu118
---extra-index-url https://download.pytorch.org/whl/cu121
-torch
+# PyTorch is installed separately by setup.bat so its package index is not
+# used to resolve unrelated dependencies from this file.
 bandit==1.7.8
 SqlAlchemy==2.0.31
 setuptools

--- a/app/transcribe/setup-sensevoice.bat
+++ b/app/transcribe/setup-sensevoice.bat
@@ -1,0 +1,53 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "PYTHON=%~dp0..\..\venv\Scripts\python.exe"
+
+if not exist "%PYTHON%" (
+    echo Transcribe virtual environment not found. Run setup.bat first.
+    exit /b 1
+)
+
+echo Checking Python version...
+"%PYTHON%" -c "import sys; exit(0 if sys.version_info[:2] == (3,11) else 1)"
+
+if errorlevel 1 (
+    echo SenseVoice currently requires Python 3.11 for Transcribe.
+    echo Recreate the venv with: py -3.11 -m venv venv
+    exit /b 1
+)
+
+echo Upgrading pip...
+"%PYTHON%" -m pip install --upgrade pip
+
+if errorlevel 1 (
+    echo Could not upgrade pip.
+    exit /b 1
+)
+
+echo Installing PyTorch and TorchAudio CPU builds...
+"%PYTHON%" -m pip install torch==2.11.0 torchaudio==2.11.0 --index-url "https://download.pytorch.org/whl/cpu"
+
+if errorlevel 1 (
+    echo Could not install PyTorch and TorchAudio CPU builds.
+    exit /b 1
+)
+
+echo Installing optional SenseVoice dependencies...
+"%PYTHON%" -m pip install -r "%~dp0requirements-sensevoice.txt"
+
+if errorlevel 1 (
+    echo Could not install the optional SenseVoice dependencies.
+    exit /b 1
+)
+
+echo Verifying installation...
+"%PYTHON%" -c "import torch, torchaudio, funasr, modelscope; from funasr import AutoModel; print('torch=' + torch.__version__); print('torchaudio=' + torchaudio.__version__); print('funasr=' + funasr.__version__); print('modelscope=' + modelscope.__version__)"
+
+if errorlevel 1 (
+    echo SenseVoice dependency verification failed.
+    exit /b 1
+)
+
+echo SenseVoice dependencies installed successfully.
+exit /b 0

--- a/app/transcribe/setup-sensevoice.bat
+++ b/app/transcribe/setup-sensevoice.bat
@@ -25,11 +25,26 @@ if errorlevel 1 (
     exit /b 1
 )
 
-echo Installing PyTorch and TorchAudio CPU builds...
-"%PYTHON%" -m pip install torch==2.11.0 torchaudio==2.11.0 --index-url "https://download.pytorch.org/whl/cpu"
+echo Checking the installed PyTorch build...
+"%PYTHON%" -c "import torch" >nul 2>&1
 
 if errorlevel 1 (
-    echo Could not install PyTorch and TorchAudio CPU builds.
+    echo PyTorch is not installed. Installing CPU builds of PyTorch and TorchAudio...
+    "%PYTHON%" -m pip install torch==2.11.0 torchaudio==2.11.0 --index-url "https://download.pytorch.org/whl/cpu"
+) else (
+    set "TORCH_INFO_FILE=%TEMP%\transcribe-torch-info-!RANDOM!.txt"
+    "%PYTHON%" -c "import torch; print(torch.__version__.split('+')[0], 'cu' + torch.version.cuda.replace('.', '') if torch.version.cuda else 'cpu')" > "!TORCH_INFO_FILE!"
+    for /f "usebackq tokens=1,2" %%A in ("!TORCH_INFO_FILE!") do (
+        set "TORCH_VERSION=%%A"
+        set "TORCH_FLAVOR=%%B"
+    )
+    del "!TORCH_INFO_FILE!"
+    echo Preserving PyTorch !TORCH_VERSION! !TORCH_FLAVOR! and installing matching TorchAudio...
+    "%PYTHON%" -m pip install torchaudio==!TORCH_VERSION! --index-url "https://download.pytorch.org/whl/!TORCH_FLAVOR!"
+)
+
+if errorlevel 1 (
+    echo Could not prepare matching PyTorch and TorchAudio builds.
     exit /b 1
 )
 
@@ -42,7 +57,7 @@ if errorlevel 1 (
 )
 
 echo Verifying installation...
-"%PYTHON%" -c "import torch, torchaudio, funasr, modelscope; from funasr import AutoModel; print('torch=' + torch.__version__); print('torchaudio=' + torchaudio.__version__); print('funasr=' + funasr.__version__); print('modelscope=' + modelscope.__version__)"
+"%PYTHON%" -c "import torch, torchaudio, funasr, modelscope; from funasr import AutoModel; print('torch=' + torch.__version__); print('torchaudio=' + torchaudio.__version__); print('cuda_available=' + str(torch.cuda.is_available())); print('device=' + (torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'CPU')); print('funasr=' + funasr.__version__); print('modelscope=' + modelscope.__version__)"
 
 if errorlevel 1 (
     echo SenseVoice dependency verification failed.

--- a/app/transcribe/tests/test_provider_stt.py
+++ b/app/transcribe/tests/test_provider_stt.py
@@ -8,6 +8,32 @@ from app.transcribe.providers import stt
 
 
 class TestSTTProviders(unittest.TestCase):
+    @patch("app.transcribe.providers.stt.tm.STTModelFactory")
+    def test_create_sensevoice_model_uses_optional_configuration(self, mock_factory_class):
+        factory = mock_factory_class.return_value
+        factory.get_stt_model_instance.return_value = "sensevoice-model"
+        config = {
+            "OpenAI": {"audio_lang": "English"},
+            "SenseVoice": {
+                "model": "FunAudioLLM/SenseVoiceSmall",
+                "device": "cpu",
+                "use_itn": False,
+            },
+        }
+
+        model = stt.create_stt_model(name="sensevoice", config=config, api=False)
+
+        self.assertEqual(model, "sensevoice-model")
+        factory.get_stt_model_instance.assert_called_once_with(
+            stt_model=stt.tm.STTEnum.SENSEVOICE_LOCAL,
+            stt_model_config={
+                "model": "FunAudioLLM/SenseVoiceSmall",
+                "device": "cpu",
+                "use_itn": False,
+                "audio_lang": "en",
+            },
+        )
+
     @patch("app.transcribe.providers.stt.WhisperCPPTranscriber")
     @patch("app.transcribe.providers.stt.create_stt_model")
     def test_create_transcriber_injects_whispercpp_preprocessor(self, mock_create_stt_model, mock_transcriber):

--- a/app/transcribe/tests/test_sensevoice_model.py
+++ b/app/transcribe/tests/test_sensevoice_model.py
@@ -1,0 +1,85 @@
+"""Tests for the optional SenseVoiceSmall STT adapter."""
+
+import os
+import sys
+import tempfile
+import types
+import unittest
+import wave
+from unittest.mock import MagicMock, patch
+
+from sdk.transcriber_models import SenseVoiceSTTModel
+
+
+class TestSenseVoiceSTTModel(unittest.TestCase):
+    def test_normalize_language_falls_back_to_auto(self):
+        self.assertEqual(SenseVoiceSTTModel._normalize_language("English"), "en")
+        self.assertEqual(SenseVoiceSTTModel._normalize_language("French"), "auto")
+
+    def test_sentence_segments_cover_full_audio_duration(self):
+        segments = SenseVoiceSTTModel._sentence_segments("First. Second!", 12.0)
+
+        self.assertEqual([segment["text"] for segment in segments], ["First.", "Second!"])
+        self.assertEqual(segments[0]["start"], 0.0)
+        self.assertEqual(segments[-1]["end"], 12.0)
+
+    def test_lazy_optional_import_and_response_normalization(self):
+        auto_model = MagicMock()
+        audio_model = auto_model.return_value
+        audio_model.generate.return_value = [{"text": "<|en|>Hello world."}]
+
+        funasr_module = types.ModuleType("funasr")
+        funasr_module.AutoModel = auto_model
+        utils_module = types.ModuleType("funasr.utils")
+        postprocess_module = types.ModuleType("funasr.utils.postprocess_utils")
+        postprocess_module.rich_transcription_postprocess = lambda text: text.replace("<|en|>", "")
+
+        with patch.dict(
+            sys.modules,
+            {
+                "funasr": funasr_module,
+                "funasr.utils": utils_module,
+                "funasr.utils.postprocess_utils": postprocess_module,
+            },
+        ):
+            model = SenseVoiceSTTModel(
+                {"audio_lang": "English", "device": "cpu", "use_itn": True}
+            )
+
+        auto_model.assert_called_once_with(
+            model="FunAudioLLM/SenseVoiceSmall",
+            vad_model="fsmn-vad",
+            hub="hf",
+            disable_pbar=True,
+            vad_kwargs={"max_single_segment_time": 30000},
+            device="cpu",
+        )
+
+        file_descriptor, wav_path = tempfile.mkstemp(suffix=".wav")
+        os.close(file_descriptor)
+        try:
+            with wave.open(wav_path, "wb") as wav_file:
+                wav_file.setnchannels(1)
+                wav_file.setsampwidth(2)
+                wav_file.setframerate(16000)
+                wav_file.writeframes(b"\x00\x00" * 16000)
+
+            response = model.get_transcription(wav_path)
+        finally:
+            os.unlink(wav_path)
+
+        self.assertEqual(response["text"], "Hello world.")
+        self.assertEqual(response["segments"][0]["end"], 1.0)
+        audio_model.generate.assert_called_once_with(
+            input=wav_path,
+            cache={},
+            language="en",
+            use_itn=True,
+            batch_size_s=60,
+            merge_vad=True,
+            merge_length_s=15,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -15,6 +15,6 @@ OpenAI:
 ```
 
 Default `base_url` for OpenAI is `https://api.openai.com/v1`
-Default `ai_model` for OpenAI is `gpt-4o`
+Default `ai_model` for OpenAI is `gpt-5.4-mini`
 
 Our users have found this to be very useful in countries like Australia and China, where they cannot access the default providers directly or it is cost prohibitive to access these providers.

--- a/docs/SenseVoice.md
+++ b/docs/SenseVoice.md
@@ -4,7 +4,7 @@ SenseVoiceSmall is available as an optional, Windows-only speech-to-text backend
 
 ## Installation
 
-SenseVoice support currently requires Python 3.11. Create the Transcribe virtual environment with Python 3.11 if needed:
+SenseVoice support currently requires Python 3.11 on Windows. Create the Transcribe virtual environment with Python 3.11 if needed:
 
 ```bat
 py -3.11 -m venv venv
@@ -13,15 +13,33 @@ python -m pip install --upgrade pip
 python -m pip install -r app\transcribe\requirements.txt
 ```
 
+Verify that the virtual environment is using Python 3.11 before installing the optional SenseVoice packages:
+
+```bat
+venv\Scripts\python.exe --version
+```
+
 Then run the Windows setup script from the repository root:
 
 ```bat
 app\transcribe\setup-sensevoice.bat
 ```
 
-The script preserves an existing CPU or CUDA PyTorch installation and installs the matching TorchAudio build. If PyTorch is not installed, it installs CPU builds of PyTorch 2.11 and TorchAudio 2.11. It then installs the optional dependencies in `requirements-sensevoice.txt`. The script stops with an error if the virtual environment is not using Python 3.11.
+The script stops with an error if the virtual environment is not using Python 3.11. It preserves an existing CPU or CUDA PyTorch installation and installs the matching TorchAudio build. If PyTorch is not installed, it installs CPU builds of PyTorch 2.11 and TorchAudio 2.11. It then installs the optional dependencies in `requirements-sensevoice.txt`.
 
-The model files are downloaded from Hugging Face on first use. SenseVoice model weights use the FunASR Model Open Source License Agreement rather than the Transcribe project license. Review the license before distributing the model files or a bundled application.
+If the base environment already uses a CUDA-enabled PyTorch build, installing SenseVoice should not switch Whisper back to CPU. Verify the active build with:
+
+```bat
+venv\Scripts\python.exe -c "import torch; print(torch.__version__); print(torch.cuda.is_available()); print(torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'CPU')"
+```
+
+## Model Download
+
+The default model is `FunAudioLLM/SenseVoiceSmall`. Model files are downloaded from Hugging Face on first use, not during dependency installation. The first transcription can take longer while the model cache is populated.
+
+The adapter explicitly uses the Hugging Face hub when loading the model. This avoids the slower international download path that can happen when the upstream default model source is used.
+
+SenseVoice model weights use the FunASR Model Open Source License Agreement rather than the Transcribe project license. Review the model license before distributing the model files or a bundled application.
 
 ## Usage
 
@@ -47,3 +65,17 @@ SenseVoice:
 ```
 
 `device: auto` uses CUDA when PyTorch detects a compatible GPU and otherwise uses the CPU. SenseVoiceSmall directly supports Chinese, English, Cantonese, Japanese, and Korean. Other configured languages use automatic language detection.
+
+## Troubleshooting
+
+If SenseVoice or Whisper is unexpectedly using CPU, check the PyTorch build inside the virtual environment:
+
+```bat
+venv\Scripts\python.exe -c "import torch; print('torch=' + torch.__version__); print('cuda_available=' + str(torch.cuda.is_available())); print(torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'CPU')"
+```
+
+If `cuda_available=False`, the virtual environment has a CPU-only PyTorch build or the NVIDIA driver is not available to PyTorch. If `python app\transcribe\main.py` uses a different Python version, run the app with the virtual environment explicitly:
+
+```bat
+venv\Scripts\python.exe app\transcribe\main.py -stt sensevoice
+```

--- a/docs/SenseVoice.md
+++ b/docs/SenseVoice.md
@@ -1,0 +1,49 @@
+# Experimental SenseVoiceSmall Backend
+
+SenseVoiceSmall is available as an optional, Windows-only speech-to-text backend. It supports ordinary file transcription and Transcribe's existing chunk-based live transcription. This integration does not implement FunASR's streaming Paraformer protocol.
+
+## Installation
+
+SenseVoice support currently requires Python 3.11. Create the Transcribe virtual environment with Python 3.11 if needed:
+
+```bat
+py -3.11 -m venv venv
+venv\Scripts\activate.bat
+python -m pip install --upgrade pip
+python -m pip install -r app\transcribe\requirements.txt
+```
+
+Then run the Windows setup script from the repository root:
+
+```bat
+app\transcribe\setup-sensevoice.bat
+```
+
+The script installs matching CPU builds of PyTorch 2.11 and TorchAudio 2.11, followed by the optional dependencies in `requirements-sensevoice.txt`. It stops with an error if the virtual environment is not using Python 3.11.
+
+The model files are downloaded from Hugging Face on first use. SenseVoice model weights use the FunASR Model Open Source License Agreement rather than the Transcribe project license. Review the license before distributing the model files or a bundled application.
+
+## Usage
+
+Select the backend on the command line:
+
+```bat
+venv\Scripts\python.exe -m app.transcribe.main -stt sensevoice
+```
+
+Transcribe a file without starting the desktop interface:
+
+```bat
+venv\Scripts\python.exe -m app.transcribe.main -stt sensevoice -t C:\path\to\audio.wav
+```
+
+The default configuration is:
+
+```yaml
+SenseVoice:
+  model: 'FunAudioLLM/SenseVoiceSmall'
+  device: 'auto'
+  use_itn: True
+```
+
+`device: auto` uses CUDA when PyTorch detects a compatible GPU and otherwise uses the CPU. SenseVoiceSmall directly supports Chinese, English, Cantonese, Japanese, and Korean. Other configured languages use automatic language detection.

--- a/docs/SenseVoice.md
+++ b/docs/SenseVoice.md
@@ -19,7 +19,7 @@ Then run the Windows setup script from the repository root:
 app\transcribe\setup-sensevoice.bat
 ```
 
-The script installs matching CPU builds of PyTorch 2.11 and TorchAudio 2.11, followed by the optional dependencies in `requirements-sensevoice.txt`. It stops with an error if the virtual environment is not using Python 3.11.
+The script preserves an existing CPU or CUDA PyTorch installation and installs the matching TorchAudio build. If PyTorch is not installed, it installs CPU builds of PyTorch 2.11 and TorchAudio 2.11. It then installs the optional dependencies in `requirements-sensevoice.txt`. The script stops with an error if the virtual environment is not using Python 3.11.
 
 The model files are downloaded from Hugging Face on first use. SenseVoice model weights use the FunASR Model Open Source License Agreement rather than the Transcribe project license. Review the license before distributing the model files or a bundled application.
 

--- a/sdk/transcriber_models.py
+++ b/sdk/transcriber_models.py
@@ -2,7 +2,9 @@ import sys
 import os
 import datetime
 import json
+import re
 import subprocess
+import wave
 from enum import Enum
 from abc import abstractmethod
 import openai
@@ -20,6 +22,7 @@ class STTEnum(Enum):
     WHISPER_API = 2
     WHISPER_CPP = 3
     DEEPGRAM_API = 4
+    SENSEVOICE_LOCAL = 5
 
 
 MODELS_DIR = f"{utilities.get_data_path(app_name='Transcribe')}/models/"
@@ -48,6 +51,8 @@ class STTModelFactory:
             return WhisperCPPSTTModel(stt_model_config=stt_model_config)
         elif stt_model == STTEnum.DEEPGRAM_API:
             return DeepgramSTTModel(stt_model_config=stt_model_config)
+        elif stt_model == STTEnum.SENSEVOICE_LOCAL:
+            return SenseVoiceSTTModel(stt_model_config=stt_model_config)
         raise ValueError("Unknown Speech to Text Model Type")
 
 
@@ -74,6 +79,118 @@ class STTModelInterface:
         """
         pass  # pylint: disable=W0107
 
+
+class SenseVoiceSTTModel(STTModelInterface):
+    """Optional Windows-only SenseVoiceSmall transcription backend."""
+
+    SUPPORTED_LANGUAGES = {"zh", "en", "yue", "ja", "ko", "auto"}
+    LANGUAGE_NAMES = {
+        "chinese": "zh",
+        "english": "en",
+        "cantonese": "yue",
+        "japanese": "ja",
+        "korean": "ko",
+        "auto": "auto",
+    }
+
+    def __init__(self, stt_model_config: dict):
+        if sys.platform != "win32":
+            raise RuntimeError("The experimental SenseVoice backend currently supports Windows only.")
+
+        try:
+            from funasr import AutoModel  # pylint: disable=import-outside-toplevel
+            from funasr.utils.postprocess_utils import (  # pylint: disable=import-outside-toplevel
+                rich_transcription_postprocess,
+            )
+        except ImportError as exception:
+            raise RuntimeError(
+                "SenseVoice dependencies are not installed. Run "
+                "'pip install -r requirements-sensevoice.txt' from app\\transcribe."
+            ) from exception
+
+        self.lang = self._normalize_language(stt_model_config.get("audio_lang", "auto"))
+        self.use_itn = bool(stt_model_config.get("use_itn", True))
+        self.postprocess = rich_transcription_postprocess
+        model_name = stt_model_config.get("model", "FunAudioLLM/SenseVoiceSmall")
+        device = stt_model_config.get("device", "auto")
+        if device == "auto":
+            device = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+        print(f"[INFO] Using SenseVoiceSmall for transcription on {device}.")
+        self.audio_model = AutoModel(
+            model=model_name,
+            vad_model="fsmn-vad",
+            hub="hf",
+            disable_pbar=True,
+            vad_kwargs={"max_single_segment_time": 30000},
+            device=device,
+        )
+
+    @classmethod
+    def _normalize_language(cls, lang: str) -> str:
+        normalized = str(lang).strip().lower()
+        normalized = cls.LANGUAGE_NAMES.get(normalized, normalized)
+        return normalized if normalized in cls.SUPPORTED_LANGUAGES else "auto"
+
+    def set_lang(self, lang: str):
+        """Set the recognition language, falling back to automatic detection."""
+        self.lang = self._normalize_language(lang)
+
+    @staticmethod
+    def _audio_duration(wav_file_path: str) -> float:
+        with wave.open(wav_file_path, "rb") as wav_file:
+            return wav_file.getnframes() / float(wav_file.getframerate())
+
+    @staticmethod
+    def _sentence_segments(text: str, duration_seconds: float) -> list[dict]:
+        sentences = [part.strip() for part in re.split(r"(?<=[.!?\u3002\uff01\uff1f])\s*", text) if part.strip()]
+        if not sentences:
+            return []
+
+        total_chars = sum(len(sentence) for sentence in sentences)
+        start = 0.0
+        segments = []
+        for segment_id, sentence in enumerate(sentences):
+            fraction = len(sentence) / total_chars if total_chars else 1 / len(sentences)
+            end = duration_seconds if segment_id == len(sentences) - 1 else start + duration_seconds * fraction
+            segments.append({"id": segment_id, "start": start, "end": end, "text": sentence})
+            start = end
+        return segments
+
+    def get_transcription(self, wav_file_path: str) -> dict:
+        """Transcribe a WAV file and normalize the result for the application."""
+        raw_response = self.audio_model.generate(
+            input=wav_file_path,
+            cache={},
+            language=self.lang,
+            use_itn=self.use_itn,
+            batch_size_s=60,
+            merge_vad=True,
+            merge_length_s=15,
+        )
+        text = " ".join(
+            self.postprocess(item.get("text", "")).strip()
+            for item in raw_response
+            if item.get("text")
+        ).strip()
+        return {
+            "text": text,
+            "segments": self._sentence_segments(text, self._audio_duration(wav_file_path)),
+            "raw_response": raw_response,
+        }
+
+    def process_response(self, response) -> str:
+        """Extract normalized transcription text."""
+        return response.get("text", "").strip() if response else ""
+
+    def get_sentences(self, wav_file_path: str) -> list[str]:
+        """Return timestamped sentences for batch file transcription."""
+        response = self.get_transcription(wav_file_path)
+        return [
+            f"{datetime.timedelta(seconds=int(segment['start']))} - "
+            f"{datetime.timedelta(seconds=int(segment['end']))}: {segment['text']}"
+            for segment in response["segments"]
+        ]
 
 class WhisperSTTModel(STTModelInterface):
     """Speech to Text using the Whisper Local model

--- a/sdk/transcriber_models.py
+++ b/sdk/transcriber_models.py
@@ -116,7 +116,7 @@ class SenseVoiceSTTModel(STTModelInterface):
         if device == "auto":
             device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
-        print(f"[INFO] Using SenseVoiceSmall for transcription on {device}.")
+        print("[INFO] Using SenseVoiceSmall for transcription.")
         self.audio_model = AutoModel(
             model=model_name,
             vad_model="fsmn-vad",

--- a/setup.bat
+++ b/setup.bat
@@ -1,8 +1,10 @@
 python --version
 python -m venv venv
 call venv\scripts\activate.bat
+python -m pip install --upgrade pip
+python -m pip install torch --index-url https://download.pytorch.org/whl/cu121
 cd app\transcribe
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
 
 echo To Run transcribe, execute the following command
 echo python main.py

--- a/tsutils/app_logging.py
+++ b/tsutils/app_logging.py
@@ -31,6 +31,7 @@ def initiate_log(config: dict) -> handlers.QueueListener:
     log_listener = handlers.QueueListener(que, handler)
     root_logger.setLevel(level=logging.INFO)
     root_logger.addHandler(queue_handler)
+    root_logger.propagate = False
     log_formatter = logging.Formatter('%(asctime)s %(levelname)s %(threadName)s: %(message)s')
     handler.setFormatter(log_formatter)
 

--- a/tsutils/tests/test_app_logging.py
+++ b/tsutils/tests/test_app_logging.py
@@ -1,0 +1,35 @@
+"""Tests for application logging configuration."""
+
+import logging
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from tsutils import app_logging
+
+
+class TestAppLogging(unittest.TestCase):
+    @patch("tsutils.app_logging.setup_logging")
+    @patch("tsutils.app_logging.utilities.get_data_path")
+    def test_application_logger_does_not_propagate_to_console(self, mock_data_path, _mock_setup):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            mock_data_path.return_value = temp_dir
+            listener = app_logging.initiate_log(
+                {"General": {"log_file": "transcribe.log"}}
+            )
+
+            try:
+                self.assertFalse(app_logging.root_logger.propagate)
+            finally:
+                listener.stop()
+                for handler in listener.handlers:
+                    handler.close()
+                for handler in list(app_logging.root_logger.handlers):
+                    app_logging.root_logger.removeHandler(handler)
+                    handler.close()
+                app_logging.root_logger.propagate = True
+                app_logging.root_logger.setLevel(logging.NOTSET)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an experimental Windows-only SenseVoiceSmall backend for live chunk and file transcription
- load optional FunASR dependencies lazily and download model assets from Hugging Face
- add a Python 3.11 setup script with pinned optional dependencies
- suppress SQLAlchemy and application logging noise while retaining file logs
- update the default OpenAI response model to `gpt-5.4-mini`
- isolate the PyTorch package index from ordinary dependency resolution

## Motivation

SenseVoiceSmall provides another local transcription option with multilingual support. Keeping its dependencies optional avoids increasing the base installation footprint for users who do not select this backend. The accompanying setup and logging changes address package compatibility issues and excessive console output found during Windows testing.

## Implementation

The new adapter normalizes configured languages, selects CPU or CUDA automatically, enables VAD, disables FunASR progress bars, and maps generated text into the response structure used by existing transcribers. The command-line provider factory accepts `sensevoice`, while the existing `WhisperTranscriber` continues to handle application-level chunk processing.

SenseVoice installation currently requires Python 3.11 on Windows. `setup-sensevoice.bat` installs matching CPU builds of PyTorch and TorchAudio before the pinned optional packages. Model files are retrieved from the Hugging Face `FunAudioLLM/SenseVoiceSmall` repository.

The base setup still installs the CUDA 12.1 PyTorch build. A follow-up can make CPU and GPU installations explicit choices to avoid the large CUDA download for CPU-only users.

## Validation

- `python -m unittest app.transcribe.tests.test_provider_stt app.transcribe.tests.test_sensevoice_model app.transcribe.db.tests.test_app_db tsutils.tests.test_app_logging`
- 8 focused tests passed
- staged diff whitespace check passed

## Notes

SenseVoice model weights use the FunASR Model Open Source License Agreement and are not bundled with this repository.

https://github.com/vivekuppal/transcribe/issues/288