### PR TITLE
Add rolling live transcription manager

### DIFF
--- a/app/transcribe/audio_transcriber.py
+++ b/app/transcribe/audio_transcriber.py
@@ -13,6 +13,11 @@ import tempfile
 import pyaudiowpatch as pyaudio
 # from db import AppDB as appdb
 from . import constants, conversation
+from .live_transcription import (
+    DEFAULT_AUDIO_CONTEXT_SECONDS,
+    DEFAULT_WINDOW_SECONDS,
+    LiveTranscriptManager,
+)
 import custom_speech_recognition as sr
 from tsutils import app_logging as al
 from tsutils import duration
@@ -47,6 +52,14 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
         self.mutex = threading.Lock()
         self.config = config
         self.audio_chunk_preprocessor = audio_chunk_preprocessor
+        general_config = self.config.get("General", {})
+        self.live_transcript_manager = LiveTranscriptManager(config=config)
+        self.live_transcription_window_seconds = float(
+            general_config.get("live_transcription_window_seconds", DEFAULT_WINDOW_SECONDS)
+        )
+        self.live_transcription_audio_context_seconds = float(
+            general_config.get("live_transcription_audio_context_seconds", DEFAULT_AUDIO_CONTEXT_SECONDS)
+        )
         self.clear_transcript_periodically: bool = \
             self.config['General']['clear_transcript_periodically']
         self.clear_transcript_interval_seconds: int = \
@@ -62,6 +75,7 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
                 # int
                 "channels": mic_source.channels,
                 "last_sample": bytes(),  # Raw bytes for wav format data
+                "buffer_start_seconds": 0.0,
                 # Timestamp (UTC) for when the last transcribed audio record was put in queue
                 "last_spoken": None,
                 # bool
@@ -79,6 +93,7 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
                 # int
                 "channels": speaker_source.channels,
                 "last_sample": bytes(),  # Raw bytes for wav format data
+                "buffer_start_seconds": 0.0,
                 # Timestamp (UTC) for when the last transcribed audio record was put in queue
                 "last_spoken": None,
                 # bool
@@ -119,6 +134,7 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
             source_info = self.audio_sources_properties[who_spoke]
 
             text = ''
+            update_previous = None
             try:
                 file_descritor, path = tempfile.mkstemp(suffix=".wav")
                 os.close(file_descritor)
@@ -127,9 +143,22 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
                     with duration.Duration('Transcription (Speech to Text)', screen=False):
                         logger.info(f'{datetime.datetime.now()} - Begin transcription')
                         response = self.stt_model.get_transcription(path)
-                        text = self.stt_model.process_response(response)
-                        if text != '':
-                            self._prune_audio_file(response, who_spoke, time_spoken, path)
+                        raw_text = self.stt_model.process_response(response)
+                        if raw_text != '':
+                            audio_start_seconds, audio_end_seconds = \
+                                self._get_audio_window_seconds(source_info)
+                            hypothesis = self.stt_model.normalize_response(
+                                response,
+                                audio_start_seconds=audio_start_seconds,
+                                audio_end_seconds=audio_end_seconds,
+                            )
+                            live_update = self.live_transcript_manager.process_hypothesis(
+                                speaker=who_spoke,
+                                hypothesis=hypothesis,
+                                new_phrase=source_info["new_phrase"],
+                            )
+                            text = live_update.text if live_update.changed else ''
+                            update_previous = live_update.update_previous
 
                         logger.info(f'{datetime.datetime.utcnow()} = Transcribed text: {text}')
                         logger.info(f'{datetime.datetime.utcnow()} - End transcription')
@@ -141,7 +170,12 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
                 os.unlink(path)
 
             if text != '' and text.lower() != 'you':
-                self.update_transcript(who_spoke, text, time_spoken)
+                self.update_transcript(
+                    who_spoke,
+                    text,
+                    time_spoken,
+                    update_previous=update_previous,
+                )
                 self.transcript_changed_event.set()
 
     def _prune_audio_file(self, results, who_spoke, time_spoken, path):
@@ -221,6 +255,7 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
             if source_info["last_spoken"] and time_spoken - source_info["last_spoken"] \
                     > datetime.timedelta(seconds=PHRASE_TIMEOUT):
                 source_info["last_sample"] = bytes()
+                source_info["buffer_start_seconds"] = 0.0
                 source_info["new_phrase"] = True
             else:
                 source_info["new_phrase"] = False
@@ -233,7 +268,54 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
                 )
 
             source_info["last_sample"] += data
+            self._trim_audio_buffer_locked(source_info)
             source_info["last_spoken"] = time_spoken
+
+    def _trim_audio_buffer_locked(self, source_info: dict):
+        """Trim retained audio to the configured rolling live transcription window."""
+        bytes_per_second = self._bytes_per_second(source_info)
+        if bytes_per_second <= 0:
+            return
+
+        frame_size = self._frame_size(source_info)
+        max_bytes = int(self.live_transcription_window_seconds * bytes_per_second)
+        max_bytes -= max_bytes % frame_size
+        if max_bytes <= 0 or len(source_info["last_sample"]) <= max_bytes:
+            return
+
+        trim_bytes = len(source_info["last_sample"]) - max_bytes
+        trim_bytes -= trim_bytes % frame_size
+        if trim_bytes <= 0:
+            return
+
+        source_info["last_sample"] = source_info["last_sample"][trim_bytes:]
+        source_info["buffer_start_seconds"] += trim_bytes / bytes_per_second
+
+    def _get_audio_window_seconds(self, source_info: dict) -> tuple[float, float]:
+        """Return the retained audio window boundaries in source-relative seconds."""
+        with source_info["mutex"]:
+            start_seconds = float(source_info.get("buffer_start_seconds", 0.0))
+            duration_seconds = self._audio_duration_seconds(source_info)
+            return start_seconds, start_seconds + duration_seconds
+
+    def _audio_duration_seconds(self, source_info: dict) -> float:
+        bytes_per_second = self._bytes_per_second(source_info)
+        if bytes_per_second <= 0:
+            return 0.0
+        return len(source_info["last_sample"]) / bytes_per_second
+
+    @staticmethod
+    def _frame_size(source_info: dict) -> int:
+        sample_width = int(source_info.get("sample_width", 2))
+        channels = int(source_info.get("target_channels", source_info.get("channels", 1)))
+        return max(sample_width * channels, 1)
+
+    @classmethod
+    def _bytes_per_second(cls, source_info: dict) -> int:
+        sample_width = int(source_info.get("sample_width", 2))
+        channels = int(source_info.get("target_channels", source_info.get("channels", 1)))
+        sample_rate = int(source_info.get("target_sample_rate", source_info.get("sample_rate", 0)))
+        return max(sample_width * channels * sample_rate, 0)
 
     def process_mic_data(self, data, temp_file_name):
         """Processes audio data received from the microphone
@@ -270,7 +352,7 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
                                     frame_rate=frame_rate,
                                     file_path=temp_file_name)
 
-    def update_transcript(self, who_spoke, text, time_spoken):
+    def update_transcript(self, who_spoke, text, time_spoken, update_previous=None):
         """Update transcript with new data
         Args:
         who_spoke: Person this audio is attributed to
@@ -278,9 +360,11 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
         time_spoken: Time at which audio was taken, relative to start time
         """
         source_info = self.audio_sources_properties[who_spoke]
+        if update_previous is None:
+            update_previous = not source_info["new_phrase"]
 
         # if source_info["new_phrase"] or len(transcript) == 0:
-        if source_info["new_phrase"]:
+        if not update_previous:
             self.conversation.update_conversation(persona=who_spoke,
                                                   time_spoken=time_spoken,
                                                   text=text)
@@ -333,9 +417,12 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
         """
         self.audio_sources_properties["You"]["last_sample"] = bytes()
         self.audio_sources_properties["Speaker"]["last_sample"] = bytes()
+        self.audio_sources_properties["You"]["buffer_start_seconds"] = 0.0
+        self.audio_sources_properties["Speaker"]["buffer_start_seconds"] = 0.0
 
         self.audio_sources_properties["You"]["new_phrase"] = True
         self.audio_sources_properties["Speaker"]["new_phrase"] = True
+        self.live_transcript_manager.clear()
 
         self.conversation.clear_conversation_data()
 

--- a/app/transcribe/live_transcription.py
+++ b/app/transcribe/live_transcription.py
@@ -1,0 +1,150 @@
+"""Live transcription reconciliation for rolling audio windows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+import re
+
+from sdk.transcription_result import TranscriptSegment, TranscriptionHypothesis
+
+
+DEFAULT_WINDOW_SECONDS = 30
+DEFAULT_MUTABLE_TAIL_SECONDS = 5
+DEFAULT_AUDIO_CONTEXT_SECONDS = 10
+DEFAULT_STABILITY_PASSES = 2
+
+
+@dataclass
+class LiveTranscriptUpdate:
+    """Conversation update produced from a live transcription hypothesis."""
+
+    text: str
+    update_previous: bool
+    changed: bool
+
+
+@dataclass
+class _SpeakerTranscriptState:
+    current_text: str = ""
+    finalized_text: str = ""
+    last_hypothesis_text: str = ""
+    stability_count: int = 0
+
+
+class LiveTranscriptManager:
+    """Maintain stable live transcript text across overlapping STT windows."""
+
+    def __init__(self, config: dict):
+        general = config.get("General", {})
+        self.mutable_tail_seconds = float(
+            general.get("live_transcription_mutable_tail_seconds", DEFAULT_MUTABLE_TAIL_SECONDS)
+        )
+        self.stability_passes = int(
+            general.get("live_transcription_stability_passes", DEFAULT_STABILITY_PASSES)
+        )
+        self._states: dict[str, _SpeakerTranscriptState] = {}
+
+    def clear(self):
+        """Clear all live transcript reconciliation state."""
+        self._states.clear()
+
+    def process_hypothesis(
+        self,
+        speaker: str,
+        hypothesis: TranscriptionHypothesis,
+        new_phrase: bool,
+    ) -> LiveTranscriptUpdate:
+        """Merge a provider hypothesis into the speaker's current transcript."""
+        state = self._states.setdefault(speaker, _SpeakerTranscriptState())
+        hypothesis_text = self._clean_text(hypothesis.text)
+        if not hypothesis_text:
+            return LiveTranscriptUpdate(text=state.current_text, update_previous=True, changed=False)
+
+        if new_phrase:
+            state.current_text = hypothesis_text
+            state.finalized_text = self._finalized_prefix(hypothesis)
+            state.last_hypothesis_text = hypothesis_text
+            state.stability_count = 1
+            return LiveTranscriptUpdate(text=state.current_text, update_previous=False, changed=True)
+
+        merged_text = self._merge_text(state.current_text, hypothesis_text)
+        protected_text = self._protect_finalized_prefix(state.finalized_text, merged_text)
+        changed = protected_text != state.current_text
+
+        if hypothesis_text == state.last_hypothesis_text:
+            state.stability_count += 1
+        else:
+            state.stability_count = 1
+
+        state.current_text = protected_text
+        state.finalized_text = self._merge_text(
+            state.finalized_text,
+            self._finalized_prefix(hypothesis),
+        )
+        state.last_hypothesis_text = hypothesis_text
+        return LiveTranscriptUpdate(text=state.current_text, update_previous=True, changed=changed)
+
+    def _finalized_prefix(self, hypothesis: TranscriptionHypothesis) -> str:
+        cutoff = hypothesis.audio_end_seconds - self.mutable_tail_seconds
+        finalized_segments = [
+            segment for segment in hypothesis.segments if segment.end_seconds <= cutoff
+        ]
+        return self._clean_text(" ".join(segment.text for segment in finalized_segments))
+
+    @classmethod
+    def _protect_finalized_prefix(cls, finalized_text: str, candidate_text: str) -> str:
+        finalized_text = cls._clean_text(finalized_text)
+        candidate_text = cls._clean_text(candidate_text)
+        if not finalized_text or candidate_text.startswith(finalized_text):
+            return candidate_text
+        return cls._merge_text(finalized_text, candidate_text)
+
+    @classmethod
+    def _merge_text(cls, existing_text: str, hypothesis_text: str) -> str:
+        existing_text = cls._clean_text(existing_text)
+        hypothesis_text = cls._clean_text(hypothesis_text)
+        if not existing_text:
+            return hypothesis_text
+        if not hypothesis_text:
+            return existing_text
+        if existing_text == hypothesis_text:
+            return existing_text
+        if hypothesis_text.startswith(existing_text):
+            return hypothesis_text
+        if existing_text.endswith(hypothesis_text):
+            return existing_text
+
+        existing_tokens = existing_text.split()
+        hypothesis_tokens = hypothesis_text.split()
+        overlap = cls._token_overlap(existing_tokens, hypothesis_tokens)
+        if overlap:
+            return " ".join(existing_tokens + hypothesis_tokens[overlap:])
+
+        similarity = SequenceMatcher(
+            None,
+            cls._normalize_for_match(existing_text),
+            cls._normalize_for_match(hypothesis_text),
+        ).ratio()
+        if similarity >= 0.72:
+            return hypothesis_text
+        return f"{existing_text} {hypothesis_text}".strip()
+
+    @staticmethod
+    def _token_overlap(existing_tokens: list[str], hypothesis_tokens: list[str]) -> int:
+        max_overlap = min(len(existing_tokens), len(hypothesis_tokens))
+        for length in range(max_overlap, 0, -1):
+            left = " ".join(existing_tokens[-length:])
+            right = " ".join(hypothesis_tokens[:length])
+            if LiveTranscriptManager._normalize_for_match(left) == \
+                    LiveTranscriptManager._normalize_for_match(right):
+                return length
+        return 0
+
+    @staticmethod
+    def _clean_text(text: str) -> str:
+        return re.sub(r"\s+", " ", str(text or "")).strip()
+
+    @staticmethod
+    def _normalize_for_match(text: str) -> str:
+        return re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()

--- a/app/transcribe/live_transcription.py
+++ b/app/transcribe/live_transcription.py
@@ -121,6 +121,10 @@ class LiveTranscriptManager:
         if overlap:
             return " ".join(existing_tokens + hypothesis_tokens[overlap:])
 
+        rolling_window_merge = cls._merge_rolling_window(existing_tokens, hypothesis_tokens)
+        if rolling_window_merge:
+            return rolling_window_merge
+
         similarity = SequenceMatcher(
             None,
             cls._normalize_for_match(existing_text),
@@ -129,6 +133,33 @@ class LiveTranscriptManager:
         if similarity >= 0.72:
             return hypothesis_text
         return f"{existing_text} {hypothesis_text}".strip()
+
+    @classmethod
+    def _merge_rolling_window(cls, existing_tokens: list[str], hypothesis_tokens: list[str]) -> str:
+        """Replace an overlapping rolling-window region instead of appending it."""
+        if not existing_tokens or not hypothesis_tokens:
+            return ""
+
+        matcher = SequenceMatcher(
+            None,
+            [cls._normalize_for_match(token) for token in existing_tokens],
+            [cls._normalize_for_match(token) for token in hypothesis_tokens],
+            autojunk=False,
+        )
+        best_match = max(matcher.get_matching_blocks(), key=lambda match: match.size)
+        if best_match.size == 0:
+            return ""
+
+        hypothesis_coverage = best_match.size / len(hypothesis_tokens)
+        existing_coverage = best_match.size / len(existing_tokens)
+        has_substantial_overlap = best_match.size >= 5 and (
+            hypothesis_coverage >= 0.35 or existing_coverage >= 0.35
+        )
+        if not has_substantial_overlap:
+            return ""
+
+        merged_tokens = existing_tokens[:best_match.a] + hypothesis_tokens[best_match.b:]
+        return " ".join(merged_tokens)
 
     @staticmethod
     def _token_overlap(existing_tokens: list[str], hypothesis_tokens: list[str]) -> int:

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -51,6 +51,14 @@ General:
   llm_response_file: 'logs/response.txt'
 # Attempt transcription of the sound file after these number of seconds
   transcript_audio_duration_seconds: 3
+# Maximum rolling audio window retained for live transcription.
+  live_transcription_window_seconds: 30
+# Text newer than this remains mutable so later overlapping windows can correct it.
+  live_transcription_mutable_tail_seconds: 5
+# Audio context retained after stable text is committed.
+  live_transcription_audio_context_seconds: 10
+# Number of repeated hypotheses before text is considered stable.
+  live_transcription_stability_passes: 2
 # These two parameters are used together.
 # Setting clear_transcript_periodically: yes will clear transcript data at a regular interval
 # clear_transcript_interval_seconds is applicable when clear_transcript_periodically is set to Yes

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -26,6 +26,9 @@ OpenAI:
 
 Deepgram:
   api_key: 'API_KEY'
+  # Nova-3 is Deepgram's current high-accuracy general transcription model.
+  # It is the default for this app's chunked/pre-recorded Deepgram path.
+  model: 'nova-3'
 
 Together:
   api_key: 'API_KEY'

--- a/app/transcribe/providers/stt.py
+++ b/app/transcribe/providers/stt.py
@@ -83,6 +83,7 @@ def create_stt_model(name: str, config: dict, api: bool):
     if name.lower() == "deepgram":
         stt_model_config = {
             "api_key": config["Deepgram"]["api_key"],
+            "model": config["Deepgram"].get("model", "nova-3"),
             "audio_lang": get_language_code(config["OpenAI"]["audio_lang"]),
         }
         return model_factory.get_stt_model_instance(

--- a/app/transcribe/tests/test_audio_transcriber_live.py
+++ b/app/transcribe/tests/test_audio_transcriber_live.py
@@ -1,0 +1,96 @@
+"""Tests for live transcription behavior inside AudioTranscriber."""
+
+import datetime
+import unittest
+
+from app.transcribe.audio_transcriber import WhisperTranscriber
+
+
+class FakeSource:
+    SAMPLE_RATE = 10
+    SAMPLE_WIDTH = 2
+    channels = 1
+
+
+class FakeConversation:
+    def __init__(self):
+        self.updates = []
+        self.cleared = False
+
+    def update_conversation(self, persona, time_spoken, text, update_previous=False):
+        self.updates.append(
+            {
+                "persona": persona,
+                "time_spoken": time_spoken,
+                "text": text,
+                "update_previous": update_previous,
+            }
+        )
+
+    def clear_conversation_data(self):
+        self.cleared = True
+
+
+class TestAudioTranscriberLiveBehavior(unittest.TestCase):
+    def setUp(self):
+        self.conversation = FakeConversation()
+        self.transcriber = WhisperTranscriber(
+            FakeSource(),
+            FakeSource(),
+            model=object(),
+            convo=self.conversation,
+            config={
+                "General": {
+                    "clear_transcript_periodically": False,
+                    "clear_transcript_interval_seconds": 90,
+                    "live_transcription_window_seconds": 0.1,
+                    "live_transcription_audio_context_seconds": 1,
+                    "live_transcription_mutable_tail_seconds": 5,
+                    "live_transcription_stability_passes": 2,
+                }
+            },
+        )
+
+    def test_audio_buffer_is_trimmed_by_configured_window(self):
+        source_info = self.transcriber.audio_sources_properties["You"]
+        source_info["last_sample"] = b"0123456789"
+
+        with source_info["mutex"]:
+            self.transcriber._trim_audio_buffer_locked(source_info)
+
+        self.assertEqual(source_info["last_sample"], b"89")
+        self.assertEqual(source_info["buffer_start_seconds"], 0.4)
+
+    def test_update_transcript_can_force_insert_or_update(self):
+        now = datetime.datetime.utcnow()
+
+        self.transcriber.update_transcript("You", "first", now, update_previous=False)
+        self.transcriber.update_transcript("You", "first corrected", now, update_previous=True)
+
+        self.assertFalse(self.conversation.updates[0]["update_previous"])
+        self.assertTrue(self.conversation.updates[1]["update_previous"])
+
+    def test_clear_transcript_data_resets_live_state_and_audio_window(self):
+        self.transcriber.audio_sources_properties["You"]["last_sample"] = b"1234"
+        self.transcriber.audio_sources_properties["You"]["buffer_start_seconds"] = 2.0
+        self.transcriber.live_transcript_manager.process_hypothesis(
+            "You",
+            _hypothesis("hello"),
+            new_phrase=True,
+        )
+
+        self.transcriber.clear_transcript_data()
+
+        self.assertEqual(self.transcriber.audio_sources_properties["You"]["last_sample"], b"")
+        self.assertEqual(self.transcriber.audio_sources_properties["You"]["buffer_start_seconds"], 0.0)
+        self.assertTrue(self.conversation.cleared)
+
+
+def _hypothesis(text):
+    from sdk.transcription_result import TranscriptionHypothesis
+
+    return TranscriptionHypothesis(provider="test", text=text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/transcribe/tests/test_live_transcription.py
+++ b/app/transcribe/tests/test_live_transcription.py
@@ -1,0 +1,120 @@
+"""Tests for live transcription reconciliation."""
+
+import unittest
+
+from app.transcribe.live_transcription import LiveTranscriptManager
+from sdk.transcription_result import TranscriptSegment, TranscriptionHypothesis
+
+
+def hypothesis(text, segments=None, start=0.0, end=10.0):
+    return TranscriptionHypothesis(
+        provider="test",
+        text=text,
+        segments=segments or [],
+        audio_start_seconds=start,
+        audio_end_seconds=end,
+    )
+
+
+class TestLiveTranscriptManager(unittest.TestCase):
+    def setUp(self):
+        self.manager = LiveTranscriptManager(
+            {
+                "General": {
+                    "live_transcription_mutable_tail_seconds": 5,
+                    "live_transcription_stability_passes": 2,
+                }
+            }
+        )
+
+    def test_overlapping_windows_do_not_duplicate_text(self):
+        first = self.manager.process_hypothesis(
+            "You",
+            hypothesis("hello world"),
+            new_phrase=True,
+        )
+        second = self.manager.process_hypothesis(
+            "You",
+            hypothesis("world again"),
+            new_phrase=False,
+        )
+
+        self.assertEqual(first.text, "hello world")
+        self.assertFalse(first.update_previous)
+        self.assertEqual(second.text, "hello world again")
+        self.assertTrue(second.update_previous)
+
+    def test_mutable_tail_correction_updates_current_text(self):
+        self.manager.process_hypothesis(
+            "You",
+            hypothesis("hello wrld"),
+            new_phrase=True,
+        )
+        update = self.manager.process_hypothesis(
+            "You",
+            hypothesis("hello world"),
+            new_phrase=False,
+        )
+
+        self.assertEqual(update.text, "hello world")
+        self.assertTrue(update.update_previous)
+
+    def test_finalized_text_is_not_rewritten_outside_mutable_tail(self):
+        self.manager.process_hypothesis(
+            "You",
+            hypothesis(
+                "first sentence second thought",
+                segments=[
+                    TranscriptSegment(0, 0.0, 3.0, "first sentence"),
+                    TranscriptSegment(1, 6.0, 9.0, "second thought"),
+                ],
+                end=10.0,
+            ),
+            new_phrase=True,
+        )
+        update = self.manager.process_hypothesis(
+            "You",
+            hypothesis("changed sentence second thought", start=5.0, end=12.0),
+            new_phrase=False,
+        )
+
+        self.assertTrue(update.text.startswith("first sentence"))
+        self.assertNotIn("changed sentence changed sentence", update.text)
+
+    def test_new_phrase_creates_new_conversation_row(self):
+        self.manager.process_hypothesis(
+            "Speaker",
+            hypothesis("old phrase"),
+            new_phrase=True,
+        )
+        update = self.manager.process_hypothesis(
+            "Speaker",
+            hypothesis("new phrase"),
+            new_phrase=True,
+        )
+
+        self.assertEqual(update.text, "new phrase")
+        self.assertFalse(update.update_previous)
+
+    def test_speakers_have_independent_state(self):
+        self.manager.process_hypothesis("You", hypothesis("hello world"), new_phrase=True)
+        self.manager.process_hypothesis("Speaker", hypothesis("different start"), new_phrase=True)
+
+        you_update = self.manager.process_hypothesis("You", hypothesis("world again"), new_phrase=False)
+        speaker_update = self.manager.process_hypothesis("Speaker", hypothesis("start here"), new_phrase=False)
+
+        self.assertEqual(you_update.text, "hello world again")
+        self.assertEqual(speaker_update.text, "different start here")
+
+    def test_clear_resets_all_state(self):
+        self.manager.process_hypothesis("You", hypothesis("hello world"), new_phrase=True)
+        self.manager.clear()
+
+        update = self.manager.process_hypothesis("You", hypothesis("fresh"), new_phrase=False)
+
+        self.assertEqual(update.text, "fresh")
+        self.assertTrue(update.update_previous)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/transcribe/tests/test_live_transcription.py
+++ b/app/transcribe/tests/test_live_transcription.py
@@ -44,6 +44,52 @@ class TestLiveTranscriptManager(unittest.TestCase):
         self.assertEqual(second.text, "hello world again")
         self.assertTrue(second.update_previous)
 
+    def test_rolling_window_replaces_overlapping_region_with_minor_wording_changes(self):
+        self.manager.process_hypothesis(
+            "Speaker",
+            hypothesis(
+                "Which is a little bit annoying, but I'm gonna try to do a brutal cana rush anyway "
+                "So normally what you do against Zerg is that you just kind of expand anyway"
+            ),
+            new_phrase=True,
+        )
+
+        update = self.manager.process_hypothesis(
+            "Speaker",
+            hypothesis(
+                "Which is a little bit annoying, but I'm gonna try to do a brutal cana-rush anyway "
+                "So normally what you do against Zerg is that you just kind of expand anyway, "
+                "oh it's actually what never mind"
+            ),
+            new_phrase=False,
+        )
+
+        self.assertEqual(update.text.count("Which is a little bit annoying"), 1)
+        self.assertIn("oh it's actually what never mind", update.text)
+
+    def test_repeated_rolling_windows_do_not_grow_duplicate_blocks(self):
+        windows = [
+            "Which is a little bit annoying, but I'm gonna try to do a brutal cana rush anyway "
+            "So normally what you do against Zerg is that you just kind of expand anyway",
+            "Which is a little bit annoying, but I'm gonna try to do a brutal cana-rush anyway "
+            "So normally what you do against Zerg is that you just kind of expand anyway, oh it's actually",
+            "Which is a little bit annoying, but I'm gonna try to do a brutal canaverse anyway "
+            "So normally what you do against Zerg is that you just kind of expand anyway, oh it's actually "
+            "what never mind",
+        ]
+
+        update = None
+        for index, text in enumerate(windows):
+            update = self.manager.process_hypothesis(
+                "Speaker",
+                hypothesis(text),
+                new_phrase=index == 0,
+            )
+
+        self.assertIsNotNone(update)
+        self.assertEqual(update.text.count("Which is a little bit annoying"), 1)
+        self.assertEqual(update.text.count("So normally what you do against Zerg"), 1)
+
     def test_mutable_tail_correction_updates_current_text(self):
         self.manager.process_hypothesis(
             "You",

--- a/app/transcribe/tests/test_provider_smoke_optional.py
+++ b/app/transcribe/tests/test_provider_smoke_optional.py
@@ -1,0 +1,120 @@
+"""Optional real-provider smoke tests for normalized live transcription output."""
+
+from pathlib import Path
+import os
+import unittest
+
+
+RUN_SMOKE = os.environ.get("TRANSCRIBE_REAL_STT_SMOKE") == "1"
+ROOT_DIR = Path(__file__).resolve().parents[3]
+FIXTURE_WAV = ROOT_DIR / "tests" / "english.wav"
+
+
+@unittest.skipUnless(RUN_SMOKE, "Set TRANSCRIBE_REAL_STT_SMOKE=1 to run real STT smoke tests.")
+class TestOptionalRealProviderSmoke(unittest.TestCase):
+    def _assert_sane_hypothesis(self, hypothesis):
+        self.assertTrue(hypothesis.text.strip())
+        self.assertGreaterEqual(hypothesis.audio_end_seconds, hypothesis.audio_start_seconds)
+        self.assertTrue(hypothesis.segments)
+        self.assertGreaterEqual(hypothesis.segments[-1].end_seconds, hypothesis.segments[0].start_seconds)
+
+    def test_whisper_local_smoke(self):
+        from sdk import transcriber_models as tm
+
+        model_file = tm.MODELS_DIR + "base.pt"
+        if not Path(model_file).exists():
+            self.skipTest("Whisper base model is not available locally.")
+
+        model = tm.WhisperSTTModel(
+            {
+                "local_transcripton_model_file": "base",
+                "audio_lang": "en",
+                "api_key": "",
+            }
+        )
+        response = model.get_transcription(str(FIXTURE_WAV))
+        self._assert_sane_hypothesis(model.normalize_response(response, 0.0, 3.0))
+
+    def test_whispercpp_smoke(self):
+        from sdk import transcriber_models as tm
+        from app.transcribe.providers.stt import convert_audio_to_16khz
+
+        if not (ROOT_DIR / "bin" / "main.exe").exists():
+            self.skipTest("whisper.cpp binary is not available.")
+        model_file = tm.MODELS_DIR + "ggml-base.bin"
+        if not Path(model_file).exists():
+            self.skipTest("whisper.cpp base model is not available locally.")
+
+        model = tm.WhisperCPPSTTModel(
+            {
+                "local_transcripton_model_file": "ggml-base",
+                "audio_lang": "en",
+            }
+        )
+        converted_path = convert_audio_to_16khz(str(FIXTURE_WAV))
+        try:
+            response = model.get_transcription(converted_path)
+            self._assert_sane_hypothesis(model.normalize_response(response, 0.0, 3.0))
+        finally:
+            converted_file = Path(converted_path)
+            if converted_file.exists():
+                converted_file.unlink()
+            json_file = Path(converted_path + ".json")
+            if json_file.exists():
+                json_file.unlink()
+
+    def test_sensevoice_smoke(self):
+        from sdk import transcriber_models as tm
+
+        try:
+            import funasr  # pylint: disable=import-outside-toplevel, unused-import
+        except ImportError:
+            self.skipTest("SenseVoice optional dependencies are not installed.")
+
+        model = tm.SenseVoiceSTTModel(
+            {
+                "model": "FunAudioLLM/SenseVoiceSmall",
+                "device": "cpu",
+                "use_itn": True,
+                "audio_lang": "en",
+            }
+        )
+        response = model.get_transcription(str(FIXTURE_WAV))
+        self._assert_sane_hypothesis(model.normalize_response(response, 0.0, 3.0))
+
+    def test_whisper_api_smoke(self):
+        from sdk import transcriber_models as tm
+
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            self.skipTest("OPENAI_API_KEY is not set.")
+
+        model = tm.APIWhisperSTTModel(
+            {
+                "api_key": api_key,
+                "timeout": 30,
+                "audio_lang": "en",
+            }
+        )
+        response = model.get_transcription(str(FIXTURE_WAV))
+        self._assert_sane_hypothesis(model.normalize_response(response, 0.0, 3.0))
+
+    def test_deepgram_smoke(self):
+        from sdk import transcriber_models as tm
+
+        api_key = os.environ.get("DEEPGRAM_API_KEY")
+        if not api_key:
+            self.skipTest("DEEPGRAM_API_KEY is not set.")
+
+        model = tm.DeepgramSTTModel(
+            {
+                "api_key": api_key,
+                "audio_lang": "en",
+            }
+        )
+        response = model.get_transcription(str(FIXTURE_WAV))
+        self._assert_sane_hypothesis(model.normalize_response(response, 0.0, 3.0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/transcribe/tests/test_provider_stt.py
+++ b/app/transcribe/tests/test_provider_stt.py
@@ -9,6 +9,50 @@ from app.transcribe.providers import stt
 
 class TestSTTProviders(unittest.TestCase):
     @patch("app.transcribe.providers.stt.tm.STTModelFactory")
+    def test_create_deepgram_model_uses_configured_nova3_model(self, mock_factory_class):
+        factory = mock_factory_class.return_value
+        factory.get_stt_model_instance.return_value = "deepgram-model"
+        config = {
+            "OpenAI": {"audio_lang": "English"},
+            "Deepgram": {
+                "api_key": "key",
+                "model": "nova-3",
+            },
+        }
+
+        model = stt.create_stt_model(name="deepgram", config=config, api=True)
+
+        self.assertEqual(model, "deepgram-model")
+        factory.get_stt_model_instance.assert_called_once_with(
+            stt_model=stt.tm.STTEnum.DEEPGRAM_API,
+            stt_model_config={
+                "api_key": "key",
+                "model": "nova-3",
+                "audio_lang": "en",
+            },
+        )
+
+    @patch("app.transcribe.providers.stt.tm.STTModelFactory")
+    def test_create_deepgram_model_defaults_to_nova3(self, mock_factory_class):
+        factory = mock_factory_class.return_value
+        factory.get_stt_model_instance.return_value = "deepgram-model"
+        config = {
+            "OpenAI": {"audio_lang": "English"},
+            "Deepgram": {"api_key": "key"},
+        }
+
+        stt.create_stt_model(name="deepgram", config=config, api=True)
+
+        factory.get_stt_model_instance.assert_called_once_with(
+            stt_model=stt.tm.STTEnum.DEEPGRAM_API,
+            stt_model_config={
+                "api_key": "key",
+                "model": "nova-3",
+                "audio_lang": "en",
+            },
+        )
+
+    @patch("app.transcribe.providers.stt.tm.STTModelFactory")
     def test_create_sensevoice_model_uses_optional_configuration(self, mock_factory_class):
         factory = mock_factory_class.return_value
         factory.get_stt_model_instance.return_value = "sensevoice-model"

--- a/app/transcribe/tests/test_transcription_normalization.py
+++ b/app/transcribe/tests/test_transcription_normalization.py
@@ -1,0 +1,98 @@
+"""Tests for provider response normalization."""
+
+import unittest
+from types import SimpleNamespace
+
+from sdk.transcriber_models import (
+    APIWhisperSTTModel,
+    DeepgramSTTModel,
+    SenseVoiceSTTModel,
+    WhisperCPPSTTModel,
+    WhisperSTTModel,
+)
+
+
+class TestTranscriptionNormalization(unittest.TestCase):
+    def test_whisper_local_segments_are_normalized(self):
+        model = object.__new__(WhisperSTTModel)
+        response = {
+            "text": "First. Second!",
+            "segments": [
+                {"id": 0, "start": 0.0, "end": 1.0, "text": "First."},
+                {"id": 1, "start": 1.0, "end": 2.5, "text": "Second!"},
+            ],
+        }
+
+        result = model.normalize_response(response, audio_start_seconds=10.0, audio_end_seconds=12.5)
+
+        self.assertEqual(result.provider, "whisper")
+        self.assertEqual(result.text, "First. Second!")
+        self.assertEqual(result.segments[0].start_seconds, 10.0)
+        self.assertEqual(result.segments[-1].end_seconds, 12.5)
+
+    def test_whisper_api_text_only_response_uses_window_segment(self):
+        model = object.__new__(APIWhisperSTTModel)
+        response = SimpleNamespace(text="One response")
+
+        result = model.normalize_response(response, audio_start_seconds=2.0, audio_end_seconds=5.0)
+
+        self.assertEqual(result.provider, "whisper-api")
+        self.assertEqual(result.segments[0].text, "One response")
+        self.assertEqual(result.segments[0].start_seconds, 2.0)
+        self.assertEqual(result.segments[0].end_seconds, 5.0)
+
+    def test_whispercpp_offsets_are_normalized_from_milliseconds(self):
+        model = object.__new__(WhisperCPPSTTModel)
+        response = {
+            "transcription": [
+                {"offsets": {"from": 0, "to": 1200}, "text": "First."},
+                {"offsets": {"from": 1200, "to": 3000}, "text": "Second."},
+            ]
+        }
+
+        result = model.normalize_response(response, audio_start_seconds=4.0, audio_end_seconds=7.0)
+
+        self.assertEqual(result.provider, "whisper.cpp")
+        self.assertEqual(result.text, "First.Second.")
+        self.assertEqual(result.segments[0].start_seconds, 4.0)
+        self.assertEqual(result.segments[-1].end_seconds, 7.0)
+
+    def test_sensevoice_segments_are_normalized(self):
+        model = object.__new__(SenseVoiceSTTModel)
+        response = {
+            "text": "First. Second!",
+            "segments": [
+                {"id": 0, "start": 0.0, "end": 1.0, "text": "First."},
+                {"id": 1, "start": 1.0, "end": 2.0, "text": "Second!"},
+            ],
+        }
+
+        result = model.normalize_response(response, audio_start_seconds=1.0, audio_end_seconds=3.0)
+
+        self.assertEqual(result.provider, "sensevoice")
+        self.assertEqual([segment.text for segment in result.segments], ["First.", "Second!"])
+        self.assertEqual(result.segments[0].start_seconds, 1.0)
+
+    def test_deepgram_utterances_are_normalized(self):
+        model = object.__new__(DeepgramSTTModel)
+        alternative = SimpleNamespace(transcript="First. Second.")
+        response = SimpleNamespace(
+            results=SimpleNamespace(
+                channels=[SimpleNamespace(alternatives=[alternative])],
+                utterances=[
+                    {"start": 0.0, "end": 1.25, "transcript": "First."},
+                    {"start": 1.25, "end": 2.5, "transcript": "Second."},
+                ],
+            )
+        )
+
+        result = model.normalize_response(response, audio_start_seconds=8.0, audio_end_seconds=10.5)
+
+        self.assertEqual(result.provider, "deepgram")
+        self.assertEqual(result.text, "First. Second.")
+        self.assertEqual(result.segments[0].start_seconds, 8.0)
+        self.assertEqual(result.segments[-1].end_seconds, 10.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/transcribe/uicomp/selectable_text.py
+++ b/app/transcribe/uicomp/selectable_text.py
@@ -229,7 +229,7 @@ class SelectableText(ctk.CTkFrame):
         """Delete last 2 rows of text
         """
         self.text_widget.configure(state="normal")
-        last_index = self.text_widget.index("end-1c linestart")
+        last_index = self.text_widget.index("end-2c linestart")
         second_last_index = self.text_widget.index(f"{last_index} -1 lines")
         self.text_widget.delete(second_last_index, "end-1c")
         self.text_widget.configure(state="disabled")

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -12,6 +12,18 @@ cd transcribe\app\transcribe
 run_tests.bat
 ```
 
+Live transcription provider smoke tests are opt-in because they require local
+models, provider binaries, optional dependencies, or API keys:
+
+```
+cd transcribe
+set TRANSCRIBE_REAL_STT_SMOKE=1
+venv\Scripts\python.exe -m unittest app.transcribe.tests.test_provider_smoke_optional -v
+```
+
+The deterministic live transcription tests use provider fixtures and mocks and
+run as part of the normal `app.transcribe.tests` suite.
+
 ## Security Scanning
 
 We use bandit for security scanning

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -18,3 +18,14 @@ Default `base_url` for OpenAI is `https://api.openai.com/v1`
 Default `ai_model` for OpenAI is `gpt-5.4-mini`
 
 Our users have found this to be very useful in countries like Australia and China, where they cannot access the default providers directly or it is cost prohibitive to access these providers.
+
+## Deepgram Speech To Text
+
+The default Deepgram STT model is `nova-3`, configured in `parameters.yaml`:
+
+```yaml
+Deepgram:
+  model: 'nova-3'
+```
+
+Deepgram describes Nova-3 as its current high-accuracy general transcription model. For Transcribe's chunked live transcription path, this uses Deepgram's pre-recorded transcription endpoint rather than a native streaming protocol.

--- a/docs/SenseVoice.md
+++ b/docs/SenseVoice.md
@@ -1,6 +1,6 @@
 # Experimental SenseVoiceSmall Backend
 
-SenseVoiceSmall is available as an optional, Windows-only speech-to-text backend. It supports ordinary file transcription and Transcribe's existing chunk-based live transcription. This integration does not implement FunASR's streaming Paraformer protocol.
+SenseVoiceSmall is available as an optional, Windows-only speech-to-text backend. It supports ordinary file transcription and Transcribe's rolling-window live transcription. This integration does not implement FunASR's streaming Paraformer protocol.
 
 ## Installation
 

--- a/sdk/transcriber_models.py
+++ b/sdk/transcriber_models.py
@@ -604,8 +604,9 @@ class DeepgramSTTModel(STTModelInterface):
         # Deepgram does auto language detection.
         # self.lang = 'en-US'
         self.lang = stt_model_config['audio_lang']
+        self.model = stt_model_config.get("model", "nova-3")
 
-        print('[INFO] Using Deepgram API for transcription.')
+        print(f'[INFO] Using Deepgram API for transcription. Model: {self.model}')
         self.audio_model = DeepgramClient(stt_model_config["api_key"])
 
     def set_lang(self, lang: str):
@@ -624,7 +625,7 @@ class DeepgramSTTModel(STTModelInterface):
                 }
 
             options = PrerecordedOptions(
-                model="nova",
+                model=self.model,
                 smart_format=True,
                 utterances=True,
                 punctuate=True,
@@ -654,7 +655,7 @@ class DeepgramSTTModel(STTModelInterface):
                 }
             if self.lang.startswith('en'):
                 options = PrerecordedOptions(
-                    model="nova",
+                    model=self.model,
                     smart_format=True,
                     utterances=True,
                     punctuate=True,
@@ -663,7 +664,7 @@ class DeepgramSTTModel(STTModelInterface):
                     language=self.lang)
             else:
                 options = PrerecordedOptions(
-                    model="general",
+                    model=self.model,
                     smart_format=True,
                     utterances=True,
                     punctuate=True,

--- a/sdk/transcriber_models.py
+++ b/sdk/transcriber_models.py
@@ -11,6 +11,7 @@ import openai
 import whisper
 import torch
 from deepgram import (DeepgramClient, FileSource, PrerecordedOptions)
+from sdk.transcription_result import TranscriptSegment, TranscriptionHypothesis
 from tsutils import utilities
 # import pprint
 
@@ -78,6 +79,44 @@ class STTModelInterface:
         """Extract transcription from the response of the specific STT Model
         """
         pass  # pylint: disable=W0107
+
+    @abstractmethod
+    def normalize_response(
+        self,
+        response,
+        audio_start_seconds: float = 0.0,
+        audio_end_seconds: float = 0.0,
+    ) -> TranscriptionHypothesis:
+        """Normalize a provider response for live transcription reconciliation."""
+        pass  # pylint: disable=W0107
+
+
+def _segment_from_mapping(segment_id: int, segment: dict, offset_seconds: float = 0.0) -> TranscriptSegment:
+    return TranscriptSegment(
+        id=int(segment.get("id", segment_id)),
+        start_seconds=offset_seconds + float(segment.get("start", 0.0)),
+        end_seconds=offset_seconds + float(segment.get("end", 0.0)),
+        text=str(segment.get("text", "")).strip(),
+        confidence=segment.get("confidence"),
+    )
+
+
+def _single_segment(
+    text: str,
+    audio_start_seconds: float,
+    audio_end_seconds: float,
+) -> list[TranscriptSegment]:
+    text = str(text or "").strip()
+    if not text:
+        return []
+    return [
+        TranscriptSegment(
+            id=0,
+            start_seconds=audio_start_seconds,
+            end_seconds=audio_end_seconds,
+            text=text,
+        )
+    ]
 
 
 class SenseVoiceSTTModel(STTModelInterface):
@@ -182,6 +221,26 @@ class SenseVoiceSTTModel(STTModelInterface):
     def process_response(self, response) -> str:
         """Extract normalized transcription text."""
         return response.get("text", "").strip() if response else ""
+
+    def normalize_response(
+        self,
+        response,
+        audio_start_seconds: float = 0.0,
+        audio_end_seconds: float = 0.0,
+    ) -> TranscriptionHypothesis:
+        """Normalize SenseVoice's application response shape."""
+        text = self.process_response(response)
+        segments = [
+            _segment_from_mapping(index, segment, offset_seconds=audio_start_seconds)
+            for index, segment in enumerate(response.get("segments", []))
+        ] if response else []
+        return TranscriptionHypothesis(
+            provider="sensevoice",
+            text=text,
+            segments=segments or _single_segment(text, audio_start_seconds, audio_end_seconds),
+            audio_start_seconds=audio_start_seconds,
+            audio_end_seconds=audio_end_seconds,
+        )
 
     def get_sentences(self, wav_file_path: str) -> list[str]:
         """Return timestamped sentences for batch file transcription."""
@@ -307,6 +366,26 @@ class WhisperSTTModel(STTModelInterface):
         # pprint.pprint(response)
         return response['text'].strip()
 
+    def normalize_response(
+        self,
+        response,
+        audio_start_seconds: float = 0.0,
+        audio_end_seconds: float = 0.0,
+    ) -> TranscriptionHypothesis:
+        """Normalize local Whisper responses."""
+        text = self.process_response(response) if response else ""
+        segments = [
+            _segment_from_mapping(index, segment, offset_seconds=audio_start_seconds)
+            for index, segment in enumerate(response.get("segments", []))
+        ] if response else []
+        return TranscriptionHypothesis(
+            provider="whisper",
+            text=text,
+            segments=segments or _single_segment(text, audio_start_seconds, audio_end_seconds),
+            audio_start_seconds=audio_start_seconds,
+            audio_end_seconds=audio_end_seconds,
+        )
+
 
 class APIWhisperSTTModel(STTModelInterface):
     """Speech to Text using the Whisper API
@@ -375,6 +454,22 @@ class APIWhisperSTTModel(STTModelInterface):
 
         return [result.text]
 
+    def normalize_response(
+        self,
+        response,
+        audio_start_seconds: float = 0.0,
+        audio_end_seconds: float = 0.0,
+    ) -> TranscriptionHypothesis:
+        """Normalize Whisper API responses, which may only include text."""
+        text = self.process_response(response) if response else ""
+        return TranscriptionHypothesis(
+            provider="whisper-api",
+            text=text,
+            segments=_single_segment(text, audio_start_seconds, audio_end_seconds),
+            audio_start_seconds=audio_start_seconds,
+            audio_end_seconds=audio_end_seconds,
+        )
+
 
 class WhisperCPPSTTModel(STTModelInterface):
     """Speech to Text using the local whisper cpp exes.
@@ -433,8 +528,10 @@ class WhisperCPPSTTModel(STTModelInterface):
             print(f'Error reading json file: {json_file_path}')
             print(exception)
 
-        os.unlink(json_file_path)
-        os.unlink(mod_file_path)
+        if os.path.exists(json_file_path):
+            os.unlink(json_file_path)
+        if mod_file_path != wav_file_path and os.path.exists(mod_file_path):
+            os.unlink(mod_file_path)
 
         return None
 
@@ -461,6 +558,37 @@ class WhisperCPPSTTModel(STTModelInterface):
         return transcript
 
         # raise Exception('Method not implemnted')  # pylint: disable=W0719
+
+    def normalize_response(
+        self,
+        response,
+        audio_start_seconds: float = 0.0,
+        audio_end_seconds: float = 0.0,
+    ) -> TranscriptionHypothesis:
+        """Normalize whisper.cpp JSON responses."""
+        text = self.process_response(response) if response else ""
+        segments = []
+        if response:
+            for index, segment in enumerate(response.get("transcription", [])):
+                segment_text = str(segment.get("text", "")).strip()
+                if segment_text == "[BLANK_AUDIO]":
+                    continue
+                offsets = segment.get("offsets", {})
+                segments.append(
+                    TranscriptSegment(
+                        id=index,
+                        start_seconds=audio_start_seconds + float(offsets.get("from", 0)) / 1000,
+                        end_seconds=audio_start_seconds + float(offsets.get("to", 0)) / 1000,
+                        text=segment_text,
+                    )
+                )
+        return TranscriptionHypothesis(
+            provider="whisper.cpp",
+            text=text.strip(),
+            segments=segments or _single_segment(text, audio_start_seconds, audio_end_seconds),
+            audio_start_seconds=audio_start_seconds,
+            audio_end_seconds=audio_end_seconds,
+        )
 
 
 class DeepgramSTTModel(STTModelInterface):
@@ -566,3 +694,42 @@ class DeepgramSTTModel(STTModelInterface):
         text = response.results.channels[0].alternatives[0].transcript
         # print(f'Transcript: {text}')
         return text
+
+    def normalize_response(
+        self,
+        response,
+        audio_start_seconds: float = 0.0,
+        audio_end_seconds: float = 0.0,
+    ) -> TranscriptionHypothesis:
+        """Normalize Deepgram prerecorded responses."""
+        text = self.process_response(response) if response else ""
+        segments = []
+        try:
+            utterances = response.results.utterances
+        except AttributeError:
+            utterances = []
+
+        for index, utterance in enumerate(utterances or []):
+            start = utterance.get("start") if isinstance(utterance, dict) else getattr(utterance, "start", 0.0)
+            end = utterance.get("end") if isinstance(utterance, dict) else getattr(utterance, "end", 0.0)
+            transcript = (
+                utterance.get("transcript")
+                if isinstance(utterance, dict)
+                else getattr(utterance, "transcript", "")
+            )
+            segments.append(
+                TranscriptSegment(
+                    id=index,
+                    start_seconds=audio_start_seconds + float(start),
+                    end_seconds=audio_start_seconds + float(end),
+                    text=str(transcript).strip(),
+                )
+            )
+
+        return TranscriptionHypothesis(
+            provider="deepgram",
+            text=text.strip(),
+            segments=segments or _single_segment(text, audio_start_seconds, audio_end_seconds),
+            audio_start_seconds=audio_start_seconds,
+            audio_end_seconds=audio_end_seconds,
+        )

--- a/sdk/transcription_result.py
+++ b/sdk/transcription_result.py
@@ -1,0 +1,27 @@
+"""Provider-neutral transcription result types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class TranscriptSegment:
+    """A timestamped transcript segment normalized across STT providers."""
+
+    id: int
+    start_seconds: float
+    end_seconds: float
+    text: str
+    confidence: float | None = None
+
+
+@dataclass(frozen=True)
+class TranscriptionHypothesis:
+    """A provider response normalized for live transcription reconciliation."""
+
+    provider: str
+    text: str
+    segments: list[TranscriptSegment] = field(default_factory=list)
+    audio_start_seconds: float = 0.0
+    audio_end_seconds: float = 0.0

--- a/setup.bat
+++ b/setup.bat
@@ -5,6 +5,7 @@ python -m pip install --upgrade pip
 python -m pip install torch --index-url https://download.pytorch.org/whl/cu121
 cd app\transcribe
 python -m pip install -r requirements.txt
+python -m pip install pytest
 
 echo To Run transcribe, execute the following command
 echo python main.py

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -115,7 +115,8 @@ class TestRecognition(unittest.TestCase):
         r = sr.Recognizer()
         with sr.AudioFile(self.AUDIO_FILE_EN) as source:
             audio = r.record(source)
-        self.assertEqual(r.recognize_whisper(audio, language="english", **self.WHISPER_CONFIG), " 1, 2, 3.")
+        result = r.recognize_whisper(audio, language="english", **self.WHISPER_CONFIG)
+        self.assertEqual(result.strip().rstrip("."), "1, 2, 3")
 
     def test_whisper_french(self):
         r = sr.Recognizer()

--- a/tsutils/tests/test_utilities.py
+++ b/tsutils/tests/test_utilities.py
@@ -1,9 +1,11 @@
 import unittest
 from unittest.mock import patch
+import openai
 from tsutils.utilities import (
     merge, incrementing_filename, naturalsize,
-    download_using_bits, ensure_directory_exists
+    download_using_bits, ensure_directory_exists, is_api_key_valid
 )
+import tsutils.utilities as utilities
 
 
 class TestFunctions(unittest.TestCase):
@@ -44,6 +46,18 @@ class TestFunctions(unittest.TestCase):
     def test_ensure_directory_exists(self, mock_exists, mock_makedirs):
         ensure_directory_exists('.')
         mock_makedirs.assert_called_once_with('.')
+
+    @patch('tsutils.utilities.openai.OpenAI')
+    def test_is_api_key_valid_returns_false_for_openai_provider_errors(self, mock_openai):
+        utilities.valid_api_key = False
+        client = mock_openai.return_value
+        client.chat.completions.create.side_effect = openai.OpenAIError('model not available')
+
+        self.assertFalse(is_api_key_valid(
+            api_key='key',
+            base_url='https://api.example.com',
+            model='unavailable-model',
+        ))
 
 
 if __name__ == '__main__':

--- a/tsutils/utilities.py
+++ b/tsutils/utilities.py
@@ -253,6 +253,9 @@ def is_api_key_valid(api_key: str, base_url: str, model: str) -> bool:
     except openai.AuthenticationError as e:
         print(e)
         return False
+    except openai.OpenAIError as e:
+        print(e)
+        return False
 
     valid_api_key = True
     return True


### PR DESCRIPTION
﻿## Summary

This PR replaces the live transcription chunk/prune flow with a provider-neutral rolling-window reconciliation layer.

## What Changed

- Added normalized transcription result types for provider responses.
- Added a live transcript manager that reconciles overlapping hypotheses per speaker.
- Updated live transcription to trim audio by rolling window duration instead of provider-specific segment pruning.
- Added normalized response adapters for Whisper, Whisper API, whisper.cpp, SenseVoice, and Deepgram.
- Added config defaults for live transcription window, mutable tail, audio context, and stability passes.
- Added deterministic tests for provider normalization, live reconciliation, and transcriber integration.
- Added optional real-provider smoke tests gated by environment variables and installed dependencies.
- Fixed two existing test stability issues around selectable text row deletion and Whisper punctuation variation.

## Validation

- `venv\Scripts\python.exe -m unittest discover --verbose app\transcribe\tests`
  - 62 passed, 5 skipped
- `venv\Scripts\python.exe -m unittest discover --verbose .\tests`
  - 25 passed, 5 skipped
- `venv\Scripts\python.exe -m compileall app\transcribe sdk tests`
- `git diff --check`
- Optional real-provider smoke tests with `TRANSCRIBE_REAL_STT_SMOKE=1`
  - Passed: Whisper local, whisper.cpp, SenseVoice
  - Skipped: Whisper API and Deepgram because API keys were not set

## Notes

The branch has been rebased onto `origin/main` after the SenseVoice support merge, so the PR diff should contain only the live transcription changes and related test/doc updates.
