### PR TITLE
Add optional diarization and transcript display updates

### DIFF
--- a/app/transcribe/audio_transcriber.py
+++ b/app/transcribe/audio_transcriber.py
@@ -7,17 +7,20 @@ import threading
 import io
 import datetime
 from abc import abstractmethod
+from collections import defaultdict
 # import pprint
 import wave
 import tempfile
 import pyaudiowpatch as pyaudio
 # from db import AppDB as appdb
 from . import constants, conversation
+from .diarization import create_diarization_service
 from .live_transcription import (
     DEFAULT_AUDIO_CONTEXT_SECONDS,
     DEFAULT_WINDOW_SECONDS,
     LiveTranscriptManager,
 )
+from sdk.transcription_result import TranscriptionHypothesis
 import custom_speech_recognition as sr
 from tsutils import app_logging as al
 from tsutils import duration
@@ -36,11 +39,13 @@ AUDIO_LENGTH_PRUNE_THRESHOLD_SECONDS = 45
 
 
 class AudioTranscriber:   # pylint: disable=C0115, R0902
+    supports_diarization = False
 
     def __init__(self, mic_source, speaker_source, model,
                  convo: conversation.Conversation,
                  config: dict,
-                 audio_chunk_preprocessor=None):
+                 audio_chunk_preprocessor=None,
+                 diarization_service=None):
         logger.info(self.__class__.__name__)
         # Transcript_data should be replaced with the conversation object.
         # We do not need to store transcription in 2 different places.
@@ -52,6 +57,8 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
         self.mutex = threading.Lock()
         self.config = config
         self.audio_chunk_preprocessor = audio_chunk_preprocessor
+        self.diarization_service = diarization_service or create_diarization_service(config)
+        self._diarized_speaker_labels: dict[str, dict[str, str]] = defaultdict(dict)
         general_config = self.config.get("General", {})
         self.live_transcript_manager = LiveTranscriptManager(config=config)
         self.live_transcription_window_seconds = float(
@@ -135,6 +142,7 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
 
             text = ''
             update_previous = None
+            live_updates = []
             try:
                 file_descritor, path = tempfile.mkstemp(suffix=".wav")
                 os.close(file_descritor)
@@ -152,13 +160,15 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
                                 audio_start_seconds=audio_start_seconds,
                                 audio_end_seconds=audio_end_seconds,
                             )
-                            live_update = self.live_transcript_manager.process_hypothesis(
-                                speaker=who_spoke,
+                            if self.supports_diarization:
+                                hypothesis = self.diarization_service.annotate_hypothesis(path, hypothesis)
+                            live_updates = self._get_live_updates(
+                                who_spoke=who_spoke,
                                 hypothesis=hypothesis,
                                 new_phrase=source_info["new_phrase"],
                             )
-                            text = live_update.text if live_update.changed else ''
-                            update_previous = live_update.update_previous
+                            if live_updates:
+                                text = " ".join(update["text"] for update in live_updates)
 
                         logger.info(f'{datetime.datetime.utcnow()} = Transcribed text: {text}')
                         logger.info(f'{datetime.datetime.utcnow()} - End transcription')
@@ -169,14 +179,81 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
                 # print(f'transcribe_audio_queue: file: {path} filesize: {os.path.getsize(path)}')
                 os.unlink(path)
 
-            if text != '' and text.lower() != 'you':
+            for update in live_updates:
+                if update["text"] == '' or update["text"].lower() == 'you':
+                    continue
                 self.update_transcript(
-                    who_spoke,
-                    text,
+                    update["speaker"],
+                    update["text"],
                     time_spoken,
-                    update_previous=update_previous,
+                    update_previous=update["update_previous"],
                 )
                 self.transcript_changed_event.set()
+
+    def _get_live_updates(
+        self,
+        who_spoke: str,
+        hypothesis: TranscriptionHypothesis,
+        new_phrase: bool,
+    ) -> list[dict]:
+        """Return conversation updates from a normalized hypothesis."""
+        diarized_hypotheses = self._split_hypothesis_by_speaker(who_spoke, hypothesis)
+        updates = []
+        for speaker, speaker_hypothesis in diarized_hypotheses:
+            live_update = self.live_transcript_manager.process_hypothesis(
+                speaker=speaker,
+                hypothesis=speaker_hypothesis,
+                new_phrase=new_phrase,
+            )
+            if live_update.changed:
+                updates.append(
+                    {
+                        "speaker": speaker,
+                        "text": live_update.text,
+                        "update_previous": live_update.update_previous,
+                    }
+                )
+        return updates
+
+    def _split_hypothesis_by_speaker(
+        self,
+        who_spoke: str,
+        hypothesis: TranscriptionHypothesis,
+    ) -> list[tuple[str, TranscriptionHypothesis]]:
+        """Split diarized segments into per-speaker hypotheses."""
+        if not hypothesis.segments or not any(segment.speaker for segment in hypothesis.segments):
+            return [(who_spoke, hypothesis)]
+
+        grouped_segments = defaultdict(list)
+        for segment in hypothesis.segments:
+            speaker = self._display_speaker_label(who_spoke, segment.speaker)
+            grouped_segments[speaker].append(segment)
+
+        split_hypotheses = []
+        for speaker, segments in grouped_segments.items():
+            split_hypotheses.append(
+                (
+                    speaker,
+                    TranscriptionHypothesis(
+                        provider=hypothesis.provider,
+                        text=" ".join(segment.text for segment in segments).strip(),
+                        segments=segments,
+                        audio_start_seconds=hypothesis.audio_start_seconds,
+                        audio_end_seconds=hypothesis.audio_end_seconds,
+                    ),
+                )
+            )
+        return split_hypotheses
+
+    def _display_speaker_label(self, source: str, diarized_speaker: str | None) -> str:
+        """Map provider speaker labels to user-facing source-specific labels."""
+        if not diarized_speaker:
+            return source
+
+        source_labels = self._diarized_speaker_labels[source]
+        if diarized_speaker not in source_labels:
+            source_labels[diarized_speaker] = f"{source} {len(source_labels) + 1}"
+        return source_labels[diarized_speaker]
 
     def _prune_audio_file(self, results, who_spoke, time_spoken, path):
         """Checks if pruning of Audio Source is required based on transcriber
@@ -359,7 +436,7 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
         text: Actual spoken words
         time_spoken: Time at which audio was taken, relative to start time
         """
-        source_info = self.audio_sources_properties[who_spoke]
+        source_info = self.audio_sources_properties[self._base_source(who_spoke)]
         if update_previous is None:
             update_previous = not source_info["new_phrase"]
 
@@ -374,6 +451,15 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
                                                   text=text,
                                                   update_previous=True)
 
+    @staticmethod
+    def _base_source(who_spoke: str) -> str:
+        """Return the audio source for a possibly diarized display speaker."""
+        if who_spoke.startswith(constants.PERSONA_YOU):
+            return constants.PERSONA_YOU
+        if who_spoke.startswith(constants.PERSONA_SPEAKER):
+            return constants.PERSONA_SPEAKER
+        return who_spoke
+
     def get_transcript(self, length: int = 0):
         """Get the audio transcript
         Args:
@@ -384,7 +470,7 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
             constants.PERSONA_YOU,
             constants.PERSONA_SPEAKER
             ]
-        convo_object_return_value = self.conversation.get_conversation(
+        convo_object_return_value = self.conversation.get_display_conversation(
             sources=sources, length=length)
         return convo_object_return_value
 
@@ -423,6 +509,7 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
         self.audio_sources_properties["You"]["new_phrase"] = True
         self.audio_sources_properties["Speaker"]["new_phrase"] = True
         self.live_transcript_manager.clear()
+        self._diarized_speaker_labels.clear()
 
         self.conversation.clear_conversation_data()
 
@@ -432,6 +519,8 @@ class WhisperTranscriber(AudioTranscriber):
     Also processes the local application state as it relates to Whisper.
     Does not interact with the Whisper API or Local Whisper SDK.
     """
+    supports_diarization = True
+
     def check_for_latency(self, results: dict) -> tuple[bool, int, float]:
         """Very long audio clips can result in latency of transcription.
         Prune long audio clips based on number of segments, audio duration.
@@ -594,6 +683,8 @@ class WhisperCPPTranscriber(AudioTranscriber):
     """Does local application specific processing related to WhisperCPPTranscriber.
     Also processes the local application state as it relates to WhisperCPP.
     """
+    supports_diarization = True
+
 
     def __init__(self, mic_source, speaker_source, model,
                  convo: conversation.Conversation, config: dict,

--- a/app/transcribe/core/conversation.py
+++ b/app/transcribe/core/conversation.py
@@ -80,7 +80,7 @@ class Conversation:
     def update_conversation_by_id(self, persona: str, convo_id: int, text: str):
         """Update a single conversation row by its persisted id."""
         with self._lock:
-            transcript = self.transcript_data[persona]
+            transcript = self.transcript_data.setdefault(persona, [])
             for index, (_, time_spoken, current_convo_id) in enumerate(transcript):
                 if current_convo_id == convo_id:
                     new_convo_text = f"{persona}: [{text}]\n\n"
@@ -108,7 +108,7 @@ class Conversation:
         callback_args = ()
 
         with self._lock:
-            transcript = self.transcript_data[persona]
+            transcript = self.transcript_data.setdefault(persona, [])
             convo_id = None
             convo_object = None
 
@@ -118,7 +118,6 @@ class Conversation:
                 convo_id = convo_object.get_max_convo_id(speaker=persona, inv_id=inv_id)
 
             convo_text = f"{persona}: [{text}]\n\n"
-            ui_text = f"{persona}: [{text}]\n"
 
             should_update_previous = (
                 update_previous
@@ -135,6 +134,7 @@ class Conversation:
                     convo_object.update_conversation(convo_id, text)
                     if persona.lower() != "assistant" and self.update_handler is not None:
                         callback = self.update_handler
+                        ui_text = self._format_display_entry(persona, text, time_spoken, newline_count=1)
                         callback_args = (persona, ui_text)
             else:
                 if (
@@ -146,6 +146,7 @@ class Conversation:
                     convo_id = convo_object.insert_conversation(inv_id, time_spoken, persona, text)
                     if self.insert_handler is not None:
                         callback = self.insert_handler
+                        ui_text = self._format_display_entry(persona, text, time_spoken, newline_count=1)
                         callback_args = (ui_text,)
 
             transcript.append((convo_text, time_spoken, convo_id))
@@ -184,9 +185,9 @@ class Conversation:
         persona = input_text[:end_speaker].strip()
         convo_id = None
         with self._lock:
-            transcript = self.transcript_data[persona]
+            transcript = self.transcript_data.get(persona, [])
             for first, _, third in transcript:
-                if first.strip() == input_text.strip():
+                if first.strip() == self._display_text_to_conversation_text(input_text).strip():
                     convo_id = third
                     break
 
@@ -201,6 +202,19 @@ class Conversation:
 
     def get_conversation(self, sources: list | None = None, length: int = 0) -> str:
         """Return a merged transcript for the requested personas."""
+        return self._get_conversation(sources=sources, length=length, display_timestamps=False)
+
+    def get_display_conversation(self, sources: list | None = None, length: int = 0) -> str:
+        """Return a merged transcript formatted for the transcript window."""
+        return self._get_conversation(sources=sources, length=length, display_timestamps=True)
+
+    def _get_conversation(
+        self,
+        sources: list | None = None,
+        length: int = 0,
+        display_timestamps: bool = False,
+    ) -> str:
+        """Return a merged transcript for the requested personas."""
         if sources is None:
             sources = [
                 constants.PERSONA_YOU,
@@ -212,31 +226,94 @@ class Conversation:
         with self._lock:
             combined_transcript = list(
                 merge(
-                    self.transcript_data[constants.PERSONA_YOU][-length:]
-                    if constants.PERSONA_YOU in sources
-                    else [],
-                    self.transcript_data[constants.PERSONA_SPEAKER][-length:]
-                    if constants.PERSONA_SPEAKER in sources
-                    else [],
-                    self.transcript_data[constants.PERSONA_ASSISTANT][-length:]
-                    if constants.PERSONA_ASSISTANT in sources
-                    else [],
-                    self.transcript_data[constants.PERSONA_SYSTEM][-length:]
-                    if constants.PERSONA_SYSTEM in sources
-                    else [],
+                    *self._transcript_lists_for_sources(sources=sources, length=length),
                     key=lambda x: x[1],
                 )
             )
             combined_transcript = combined_transcript[-length:]
+            if display_timestamps:
+                return "".join(
+                    [
+                        self._format_display_conversation_text(t[0], t[1])
+                        for t in combined_transcript
+                    ]
+                )
             return "".join([t[0] for t in combined_transcript])
+
+    @classmethod
+    def _format_display_entry(
+        cls,
+        persona: str,
+        text: str,
+        time_spoken,
+        newline_count: int = 2,
+    ) -> str:
+        """Format one transcript row for the desktop transcript view."""
+        return f"{persona}: [{cls._format_timestamp(time_spoken)}] [{text}]" + ("\n" * newline_count)
+
+    @classmethod
+    def _format_display_conversation_text(cls, conversation_text: str, time_spoken) -> str:
+        """Add a timestamp to a stored conversation row for display."""
+        stripped_text = conversation_text.strip()
+        speaker_end = stripped_text.find(":")
+        if speaker_end == -1:
+            return conversation_text
+
+        persona = stripped_text[:speaker_end].strip()
+        text = stripped_text[speaker_end + 1 :].strip()
+        if text.startswith("[") and text.endswith("]"):
+            text = text[1:-1]
+
+        return cls._format_display_entry(persona, text, time_spoken)
+
+    @staticmethod
+    def _format_timestamp(time_spoken) -> str:
+        """Format a transcript timestamp in local clock time."""
+        if hasattr(time_spoken, "strftime"):
+            if time_spoken.tzinfo is None:
+                time_spoken = time_spoken.replace(tzinfo=datetime.timezone.utc)
+            return time_spoken.astimezone().strftime("%H:%M:%S")
+        return str(time_spoken)
+
+    @staticmethod
+    def _display_text_to_conversation_text(input_text: str) -> str:
+        """Remove a display timestamp from a transcript row."""
+        stripped_text = input_text.strip()
+        speaker_end = stripped_text.find(":")
+        if speaker_end == -1:
+            return input_text
+
+        persona = stripped_text[:speaker_end].strip()
+        remainder = stripped_text[speaker_end + 1 :].strip()
+        if not remainder.startswith("["):
+            return input_text
+
+        timestamp_end = remainder.find("]")
+        remaining_text = remainder[timestamp_end + 1 :].strip() if timestamp_end != -1 else ""
+        timestamp_text = remainder[1:timestamp_end] if timestamp_end != -1 else ""
+        if timestamp_end == -1 or not remaining_text.startswith("[") or not Conversation._is_display_timestamp(timestamp_text):
+            return input_text
+
+        return f"{persona}: {remaining_text}"
+
+    @staticmethod
+    def _is_display_timestamp(value: str) -> bool:
+        """Return whether text matches the transcript display timestamp format."""
+        parts = value.split(":")
+        return len(parts) == 3 and all(part.isdigit() and len(part) == 2 for part in parts)
 
     def get_merged_conversation_summary(self, length: int = 0) -> list:
         """Return the conversation history formatted for summary prompts."""
         with self._lock:
-            combined_transcript = (
-                self.transcript_data[constants.PERSONA_YOU][-length:]
-                + self.transcript_data[constants.PERSONA_SPEAKER][-length:]
-                + self.transcript_data[constants.PERSONA_ASSISTANT][-length:]
+            combined_transcript = self._flatten_transcript_lists(
+                self._transcript_lists_for_sources(
+                    sources=[
+                        constants.PERSONA_YOU,
+                        constants.PERSONA_SPEAKER,
+                        constants.PERSONA_ASSISTANT,
+                    ],
+                    length=length,
+                )
             )
             sorted_transcript = sorted(combined_transcript, key=lambda x: x[1])
             sorted_transcript = sorted_transcript[-length:]
@@ -254,10 +331,15 @@ class Conversation:
     def get_merged_conversation_response(self, length: int = 0) -> list:
         """Return the conversation history formatted for response prompts."""
         with self._lock:
-            combined_transcript = (
-                self.transcript_data[constants.PERSONA_YOU][-length:]
-                + self.transcript_data[constants.PERSONA_SPEAKER][-length:]
-                + self.transcript_data[constants.PERSONA_ASSISTANT][-length:]
+            combined_transcript = self._flatten_transcript_lists(
+                self._transcript_lists_for_sources(
+                    sources=[
+                        constants.PERSONA_YOU,
+                        constants.PERSONA_SPEAKER,
+                        constants.PERSONA_ASSISTANT,
+                    ],
+                    length=length,
+                )
             )
             sorted_transcript = sorted(combined_transcript, key=lambda x: x[1])
             sorted_transcript = sorted_transcript[-length:]
@@ -274,3 +356,23 @@ class Conversation:
             print(f"    {item[1]}")
             print("  }")
         print("]")
+
+    def _transcript_lists_for_sources(self, sources: list, length: int = 0) -> list[list]:
+        """Return transcript lists matching exact or diarized source personas."""
+        return [
+            transcript[-length:]
+            for persona, transcript in self.transcript_data.items()
+            if self._persona_matches_sources(persona, sources)
+        ]
+
+    @staticmethod
+    def _flatten_transcript_lists(transcript_lists: list[list]) -> list:
+        """Flatten transcript list groups."""
+        return [item for transcript in transcript_lists for item in transcript]
+
+    @staticmethod
+    def _persona_matches_sources(persona: str, sources: list) -> bool:
+        """Return whether a persona should be included for requested sources."""
+        if persona in sources:
+            return True
+        return any(persona.startswith(f"{source} ") for source in sources)

--- a/app/transcribe/desktop/bindings.py
+++ b/app/transcribe/desktop/bindings.py
@@ -7,6 +7,9 @@ from tktooltip import ToolTip
 from tsutils import utilities
 
 
+TOOLTIP_FONT_SIZE = 12
+
+
 class DesktopCommandBinder:
     """Bind menu items, widget commands, and availability state."""
 
@@ -118,10 +121,12 @@ class DesktopCommandBinder:
             button.configure(state="disabled")
 
         tooltip_message = "Add API Key in override.yaml to enable button"
+        tooltip_font = ("Arial", TOOLTIP_FONT_SIZE)
         for button in disabled_buttons:
             self.tooltip_factory(
                 button,
                 msg=tooltip_message,
+                font=tooltip_font,
                 delay=0.01,
                 follow=True,
                 parent_kwargs={"padx": 3, "pady": 3},

--- a/app/transcribe/desktop/display.py
+++ b/app/transcribe/desktop/display.py
@@ -10,6 +10,8 @@ import customtkinter as ctk
 import pyperclip
 from PIL import Image, ImageTk
 
+from ..core.conversation import Conversation
+
 
 class DesktopDisplayManager:
     """Encapsulate widget-facing display updates for the desktop UI."""
@@ -136,12 +138,13 @@ class DesktopDisplayManager:
         """Open an editor for the current transcript line."""
         current_line = self.ui.transcript_text.text_widget.index("insert linestart")
         current_line_text = self.ui.transcript_text.text_widget.get(current_line, f"{current_line} lineend")
-        end_speaker = current_line_text.find(":")
+        conversation_line_text = Conversation._display_text_to_conversation_text(current_line_text)
+        end_speaker = conversation_line_text.find(":")
         if end_speaker == -1:
             return
 
-        speaker = current_line_text[:end_speaker].strip()
-        speaker_text = current_line_text[end_speaker + 1 :].strip().strip("[]")
+        speaker = conversation_line_text[:end_speaker].strip()
+        speaker_text = conversation_line_text[end_speaker + 1 :].strip().strip("[]")
 
         edit_window = tk.Toplevel(self.ui)
         edit_window.title("Edit Line")
@@ -164,7 +167,7 @@ class DesktopDisplayManager:
             text_widget = self.ui.transcript_text.text_widget
             text_widget.configure(state="normal")
             text_widget.delete(current_line, f"{current_line} lineend")
-            text_widget.insert(current_line, f"{speaker}: {new_text}")
+            text_widget.insert(current_line, self._replace_display_line_text(current_line_text, speaker, new_text))
             text_widget.configure(state="disabled")
 
             convo_id = runtime.convo.get_convo_id(persona=speaker, input_text=speaker_text)
@@ -177,6 +180,28 @@ class DesktopDisplayManager:
             padx=10,
             pady=10,
         )
+
+    @staticmethod
+    def _replace_display_line_text(current_line_text: str, speaker: str, new_text: str) -> str:
+        """Replace transcript text while preserving an existing display timestamp."""
+        stripped_text = current_line_text.strip()
+        speaker_end = stripped_text.find(":")
+        if speaker_end == -1:
+            return f"{speaker}: [{new_text}]"
+
+        remainder = stripped_text[speaker_end + 1 :].strip()
+        if remainder.startswith("["):
+            timestamp_end = remainder.find("]")
+            remaining_text = remainder[timestamp_end + 1 :].strip() if timestamp_end != -1 else ""
+            timestamp_text = remainder[1:timestamp_end] if timestamp_end != -1 else ""
+            if (
+                timestamp_end != -1
+                and remaining_text.startswith("[")
+                and Conversation._is_display_timestamp(timestamp_text)
+            ):
+                return f"{speaker}: [{timestamp_text}] [{new_text}]"
+
+        return f"{speaker}: [{new_text}]"
 
     def update_transcript_ui(self, transcriber, textbox, runtime):
         """Refresh the transcript textbox if conversation state changed."""

--- a/app/transcribe/desktop/view.py
+++ b/app/transcribe/desktop/view.py
@@ -12,6 +12,9 @@ from ..uicomp.selectable_text import SelectableText
 from tsutils.language import LANGUAGES_DICT
 
 
+MENU_FONT_SIZE = 12
+
+
 class DesktopViewBuilder:
     """Build the desktop window layout and widgets."""
 
@@ -33,10 +36,12 @@ class DesktopViewBuilder:
 
     def create_menus(self, ui):
         """Create the window menu shells without binding commands."""
-        ui.menubar = tk.Menu(ui)
-        ui.filemenu = tk.Menu(ui.menubar, tearoff=False)
-        ui.editmenu = tk.Menu(ui.menubar, tearoff=False)
-        ui.helpmenu = tk.Menu(ui.menubar, tearoff=False)
+        menu_font = ("Arial", MENU_FONT_SIZE)
+        ui.option_add("*Menu.font", menu_font)
+        ui.menubar = tk.Menu(ui, font=menu_font)
+        ui.filemenu = tk.Menu(ui.menubar, tearoff=False, font=menu_font)
+        ui.editmenu = tk.Menu(ui.menubar, tearoff=False, font=menu_font)
+        ui.helpmenu = tk.Menu(ui.menubar, tearoff=False, font=menu_font)
 
         ui.menubar.add_cascade(label="File", menu=ui.filemenu)
         ui.menubar.add_cascade(label="Edit", menu=ui.editmenu)

--- a/app/transcribe/diarization.py
+++ b/app/transcribe/diarization.py
@@ -1,0 +1,206 @@
+"""Optional speaker diarization helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import os
+import warnings
+
+from sdk.transcription_result import TranscriptSegment, TranscriptionHypothesis
+
+
+DEFAULT_PYANNOTE_MODEL = "pyannote/speaker-diarization-community-1"
+
+
+@dataclass(frozen=True)
+class DiarizationTurn:
+    """A speaker-labeled time range."""
+
+    start_seconds: float
+    end_seconds: float
+    speaker: str
+
+
+class DiarizationService:
+    """Base interface for optional diarization services."""
+
+    enabled = False
+
+    def warm_up(self):
+        """Load any model resources needed before live transcription begins."""
+
+    def diarize(self, wav_file_path: str, audio_start_seconds: float = 0.0) -> list[DiarizationTurn]:
+        """Return speaker turns for the given WAV file."""
+        return []
+
+    def annotate_hypothesis(
+        self,
+        wav_file_path: str,
+        hypothesis: TranscriptionHypothesis,
+    ) -> TranscriptionHypothesis:
+        """Attach speaker labels to a transcription hypothesis."""
+        if not self.enabled or not hypothesis.segments:
+            return hypothesis
+
+        turns = self.diarize(wav_file_path, audio_start_seconds=hypothesis.audio_start_seconds)
+        if not turns:
+            return hypothesis
+
+        return annotate_hypothesis_with_turns(hypothesis, turns)
+
+
+class PyannoteDiarizationService(DiarizationService):
+    """Pyannote.audio-backed diarization service."""
+
+    enabled = True
+
+    def __init__(
+        self,
+        model_name: str = DEFAULT_PYANNOTE_MODEL,
+        auth_token: str | None = None,
+        device: str = "auto",
+    ):
+        self.model_name = model_name
+        self.auth_token = auth_token
+        self.device = device
+        self._pipeline = None
+
+    def diarize(self, wav_file_path: str, audio_start_seconds: float = 0.0) -> list[DiarizationTurn]:
+        pipeline = self._get_pipeline()
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=r"std\(\): degrees of freedom is <= 0.*",
+                category=UserWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message=r"Mean of empty slice",
+                category=RuntimeWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message=r"invalid value encountered in divide",
+                category=RuntimeWarning,
+            )
+            diarization_output = pipeline(self._load_audio(wav_file_path))
+
+        diarization = self._extract_annotation(diarization_output)
+        if diarization is None:
+            return []
+
+        turns = []
+        for segment, _, speaker in diarization.itertracks(yield_label=True):
+            turns.append(
+                DiarizationTurn(
+                    start_seconds=audio_start_seconds + float(segment.start),
+                    end_seconds=audio_start_seconds + float(segment.end),
+                    speaker=str(speaker),
+                )
+            )
+        return turns
+
+    def warm_up(self):
+        """Load the pyannote pipeline and model before transcription starts."""
+        self._get_pipeline()
+
+    @staticmethod
+    def _extract_annotation(diarization_output):
+        """Return a pyannote Annotation from pipeline outputs across pyannote versions."""
+        if hasattr(diarization_output, "itertracks"):
+            return diarization_output
+        if hasattr(diarization_output, "exclusive_speaker_diarization"):
+            return diarization_output.exclusive_speaker_diarization
+        if hasattr(diarization_output, "speaker_diarization"):
+            return diarization_output.speaker_diarization
+        if hasattr(diarization_output, "diarization"):
+            return diarization_output.diarization
+        return None
+
+    def _get_pipeline(self):
+        if self._pipeline is not None:
+            return self._pipeline
+
+        try:
+            import torch
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message=r"\s*torchcodec is not installed correctly.*",
+                    category=UserWarning,
+                )
+                from pyannote.audio import Pipeline
+        except ImportError as exception:
+            raise RuntimeError(
+                "Diarization is enabled, but pyannote.audio is not installed. "
+                "Install app/transcribe/requirements-diarization.txt first."
+            ) from exception
+
+        try:
+            self._pipeline = Pipeline.from_pretrained(self.model_name, token=self.auth_token)
+        except TypeError:
+            self._pipeline = Pipeline.from_pretrained(self.model_name, use_auth_token=self.auth_token)
+
+        device_name = self.device
+        if device_name == "auto":
+            device_name = "cuda" if torch.cuda.is_available() else "cpu"
+        self._pipeline.to(torch.device(device_name))
+        return self._pipeline
+
+    @staticmethod
+    def _load_audio(wav_file_path: str) -> dict:
+        """Load audio explicitly so pyannote does not depend on torchcodec decoding."""
+        try:
+            import soundfile as sf
+            import torch
+        except ImportError as exception:
+            raise RuntimeError(
+                "Diarization requires soundfile and torch. "
+                "Install app/transcribe/requirements-diarization.txt first."
+            ) from exception
+
+        audio, sample_rate = sf.read(wav_file_path, always_2d=True, dtype="float32")
+        waveform = torch.from_numpy(audio.T)
+        return {"waveform": waveform, "sample_rate": sample_rate}
+
+
+def create_diarization_service(config: dict) -> DiarizationService:
+    """Create the configured optional diarization service."""
+    diarization_config = config.get("Diarization", {})
+    enabled = bool(diarization_config.get("enabled", False))
+    if not enabled:
+        return DiarizationService()
+
+    provider = str(diarization_config.get("provider", "pyannote")).lower()
+    if provider != "pyannote":
+        raise ValueError(f"Unsupported diarization provider: {provider}")
+
+    auth_token = diarization_config.get("huggingface_token") or os.environ.get("HUGGINGFACE_TOKEN")
+    return PyannoteDiarizationService(
+        model_name=diarization_config.get("model", DEFAULT_PYANNOTE_MODEL),
+        auth_token=auth_token,
+        device=diarization_config.get("device", "auto"),
+    )
+
+
+def annotate_hypothesis_with_turns(
+    hypothesis: TranscriptionHypothesis,
+    turns: list[DiarizationTurn],
+) -> TranscriptionHypothesis:
+    """Assign each transcript segment to the overlapping diarization speaker."""
+    annotated_segments = [
+        replace(segment, speaker=_best_speaker_for_segment(segment, turns))
+        for segment in hypothesis.segments
+    ]
+    return replace(hypothesis, segments=annotated_segments)
+
+
+def _best_speaker_for_segment(segment: TranscriptSegment, turns: list[DiarizationTurn]) -> str | None:
+    best_speaker = None
+    best_overlap = 0.0
+    for turn in turns:
+        overlap = min(segment.end_seconds, turn.end_seconds) - max(segment.start_seconds, turn.start_seconds)
+        if overlap > best_overlap:
+            best_overlap = overlap
+            best_speaker = turn.speaker
+    return best_speaker

--- a/app/transcribe/live_transcription.py
+++ b/app/transcribe/live_transcription.py
@@ -174,7 +174,76 @@ class LiveTranscriptManager:
 
     @staticmethod
     def _clean_text(text: str) -> str:
-        return re.sub(r"\s+", " ", str(text or "")).strip()
+        text = re.sub(r"\s+", " ", str(text or "")).strip()
+        text = LiveTranscriptManager._collapse_repeated_sentences(text)
+        text = LiveTranscriptManager._collapse_repeated_token_phrases(text)
+        return text
+
+    @staticmethod
+    def _collapse_repeated_sentences(text: str) -> str:
+        sentences = re.findall(r"[^.!?]+[.!?]|[^.!?]+$", text)
+        if len(sentences) < 3:
+            return text
+
+        collapsed = []
+        index = 0
+        while index < len(sentences):
+            sentence = sentences[index].strip()
+            normalized = LiveTranscriptManager._normalize_for_match(sentence)
+            repeat_count = 1
+            while (
+                index + repeat_count < len(sentences)
+                and LiveTranscriptManager._normalize_for_match(sentences[index + repeat_count]) == normalized
+            ):
+                repeat_count += 1
+
+            collapsed.extend([sentence] if repeat_count >= 3 else [s.strip() for s in sentences[index:index + repeat_count]])
+            index += repeat_count
+
+        return " ".join(sentence for sentence in collapsed if sentence).strip()
+
+    @staticmethod
+    def _collapse_repeated_token_phrases(text: str) -> str:
+        tokens = text.split()
+        if len(tokens) < 9:
+            return text
+
+        output = []
+        index = 0
+        while index < len(tokens):
+            phrase_length, repeat_count = LiveTranscriptManager._repeated_phrase_at(tokens, index)
+            if repeat_count >= 3:
+                output.extend(tokens[index:index + phrase_length])
+                index += phrase_length * repeat_count
+            else:
+                output.append(tokens[index])
+                index += 1
+
+        return " ".join(output).strip()
+
+    @staticmethod
+    def _repeated_phrase_at(tokens: list[str], start: int) -> tuple[int, int]:
+        remaining = len(tokens) - start
+        max_phrase_length = min(12, remaining // 3)
+        normalized_tokens = [
+            LiveTranscriptManager._normalize_for_match(token)
+            for token in tokens
+        ]
+        for phrase_length in range(max_phrase_length, 2, -1):
+            phrase = normalized_tokens[start:start + phrase_length]
+            if not any(phrase):
+                continue
+
+            repeat_count = 1
+            next_start = start + phrase_length
+            while normalized_tokens[next_start:next_start + phrase_length] == phrase:
+                repeat_count += 1
+                next_start += phrase_length
+
+            if repeat_count >= 3:
+                return phrase_length, repeat_count
+
+        return 0, 0
 
     @staticmethod
     def _normalize_for_match(text: str) -> str:

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -46,6 +46,15 @@ SenseVoice:
   device: 'auto'  # auto, cpu, or cuda:0
   use_itn: True
 
+Diarization:
+  # Optional speaker diarization. Run setup-diarization.bat first.
+  enabled: False
+  provider: 'pyannote'
+  model: 'pyannote/speaker-diarization-community-1'
+  device: 'auto'  # auto, cpu, or cuda
+  # Prefer setting HUGGINGFACE_TOKEN in the environment instead of storing it here.
+  huggingface_token: ''
+
 General:
   log_file: 'logs/Transcribe.log'
   # These two parameters are used together.

--- a/app/transcribe/providers/stt.py
+++ b/app/transcribe/providers/stt.py
@@ -170,6 +170,10 @@ def create_transcriber(name: str, config: dict, api: bool, runtime):
             config=config,
         )
 
+    if transcriber.supports_diarization and transcriber.diarization_service.enabled:
+        print("[INFO] Loading diarization model. This may download model files on first use.")
+        transcriber.diarization_service.warm_up()
+
     runtime.set_transcriber(transcriber)
     return transcriber
 

--- a/app/transcribe/requirements-diarization.txt
+++ b/app/transcribe/requirements-diarization.txt
@@ -1,0 +1,3 @@
+# Optional dependencies for speaker diarization.
+# Install the base requirements first, then install this file.
+pyannote.audio==4.0.4

--- a/app/transcribe/requirements.txt
+++ b/app/transcribe/requirements.txt
@@ -4,7 +4,7 @@ openai-whisper==20250625
 Wave==0.0.2
 standard-aifc==3.13.0; python_version >= "3.13"
 audioop-lts==0.2.2; python_version >= "3.13"
-openai==1.66.3  # Latest release as of 2025-03-17
+openai==2.41.1
 customtkinter==5.2.2
 tkinter-tooltip  # Needed to show tooltips for ctk components
 PyAudioWPatch==0.2.12.8

--- a/app/transcribe/setup-diarization.bat
+++ b/app/transcribe/setup-diarization.bat
@@ -1,0 +1,13 @@
+@echo off
+REM Optional speaker diarization dependencies.
+REM Run from the repository root after setup.bat:
+REM   app\transcribe\setup-diarization.bat
+
+call venv\scripts\activate.bat
+python -m pip install -r app\transcribe\requirements-diarization.txt
+REM pyannote.audio depends on torch and may resolve CPU wheels from PyPI.
+REM Reinstall the CUDA-enabled PyTorch stack after pyannote so Whisper and diarization can use GPU.
+python -m pip install --force-reinstall torch==2.11.0+cu126 torchaudio==2.11.0+cu126 torchcodec==0.14.0+cu126 --index-url https://download.pytorch.org/whl/cu126
+
+echo Diarization dependencies installed.
+echo Set HUGGINGFACE_TOKEN or Diarization.huggingface_token before enabling diarization.

--- a/app/transcribe/tests/test_audio_transcriber_live.py
+++ b/app/transcribe/tests/test_audio_transcriber_live.py
@@ -4,6 +4,7 @@ import datetime
 import unittest
 
 from app.transcribe.audio_transcriber import WhisperTranscriber
+from sdk.transcription_result import TranscriptSegment, TranscriptionHypothesis
 
 
 class FakeSource:
@@ -70,6 +71,28 @@ class TestAudioTranscriberLiveBehavior(unittest.TestCase):
         self.assertFalse(self.conversation.updates[0]["update_previous"])
         self.assertTrue(self.conversation.updates[1]["update_previous"])
 
+    def test_diarized_hypothesis_creates_per_speaker_updates(self):
+        hypothesis = TranscriptionHypothesis(
+            provider="test",
+            text="first second",
+            segments=[
+                TranscriptSegment(0, 0.0, 1.0, "first", speaker="SPEAKER_00"),
+                TranscriptSegment(1, 1.0, 2.0, "second", speaker="SPEAKER_01"),
+            ],
+            audio_start_seconds=0.0,
+            audio_end_seconds=2.0,
+        )
+
+        updates = self.transcriber._get_live_updates("Speaker", hypothesis, new_phrase=True)
+
+        self.assertEqual(
+            updates,
+            [
+                {"speaker": "Speaker 1", "text": "first", "update_previous": False},
+                {"speaker": "Speaker 2", "text": "second", "update_previous": False},
+            ],
+        )
+
     def test_clear_transcript_data_resets_live_state_and_audio_window(self):
         self.transcriber.audio_sources_properties["You"]["last_sample"] = b"1234"
         self.transcriber.audio_sources_properties["You"]["buffer_start_seconds"] = 2.0
@@ -87,8 +110,6 @@ class TestAudioTranscriberLiveBehavior(unittest.TestCase):
 
 
 def _hypothesis(text):
-    from sdk.transcription_result import TranscriptionHypothesis
-
     return TranscriptionHypothesis(provider="test", text=text)
 
 

--- a/app/transcribe/tests/test_core_conversation.py
+++ b/app/transcribe/tests/test_core_conversation.py
@@ -1,0 +1,75 @@
+"""Unit tests for core conversation formatting helpers."""
+
+import datetime
+import threading
+import unittest
+
+from app.transcribe import constants
+from app.transcribe.core.conversation import Conversation
+
+
+class TestConversationDisplayFormatting(unittest.TestCase):
+    def setUp(self):
+        self.conversation = Conversation.__new__(Conversation)
+        self.conversation.transcript_data = {
+            constants.PERSONA_SYSTEM: [],
+            constants.PERSONA_YOU: [],
+            constants.PERSONA_SPEAKER: [],
+            constants.PERSONA_ASSISTANT: [],
+        }
+        self.conversation._lock = threading.RLock()
+
+    def test_get_display_conversation_adds_timestamps(self):
+        spoken_time = datetime.datetime(2026, 6, 16, 14, 5, 6)
+        self.conversation.transcript_data[constants.PERSONA_YOU].append(
+            ("You: [hello there]\n\n", spoken_time, 12)
+        )
+        expected_time = spoken_time.replace(tzinfo=datetime.timezone.utc).astimezone().strftime("%H:%M:%S")
+
+        transcript = self.conversation.get_display_conversation(sources=[constants.PERSONA_YOU])
+
+        self.assertEqual(transcript, f"You: [{expected_time}] [hello there]\n\n")
+
+    def test_get_conversation_keeps_raw_text_without_timestamps(self):
+        spoken_time = datetime.datetime(2026, 6, 16, 14, 5, 6)
+        self.conversation.transcript_data[constants.PERSONA_SPEAKER].append(
+            ("Speaker: [raw transcript]\n\n", spoken_time, 13)
+        )
+
+        transcript = self.conversation.get_conversation(sources=[constants.PERSONA_SPEAKER])
+
+        self.assertEqual(transcript, "Speaker: [raw transcript]\n\n")
+
+    def test_get_conversation_includes_diarized_source_personas(self):
+        spoken_time = datetime.datetime(2026, 6, 16, 14, 5, 6)
+        self.conversation.transcript_data["Speaker 1"] = [
+            ("Speaker 1: [first speaker]\n\n", spoken_time, 13)
+        ]
+        self.conversation.transcript_data["Speaker 2"] = [
+            ("Speaker 2: [second speaker]\n\n", spoken_time + datetime.timedelta(seconds=1), 14)
+        ]
+
+        transcript = self.conversation.get_conversation(sources=[constants.PERSONA_SPEAKER])
+
+        self.assertEqual(
+            transcript,
+            "Speaker 1: [first speaker]\n\nSpeaker 2: [second speaker]\n\n",
+        )
+
+    def test_display_text_to_conversation_text_removes_timestamp(self):
+        normalized = Conversation._display_text_to_conversation_text(
+            "Speaker: [14:05:06] [timestamped transcript]"
+        )
+
+        self.assertEqual(normalized, "Speaker: [timestamped transcript]")
+
+    def test_display_text_to_conversation_text_keeps_bracketed_transcript_text(self):
+        normalized = Conversation._display_text_to_conversation_text(
+            "Speaker: [not time] [actual words]"
+        )
+
+        self.assertEqual(normalized, "Speaker: [not time] [actual words]")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/transcribe/tests/test_desktop_bindings.py
+++ b/app/transcribe/tests/test_desktop_bindings.py
@@ -66,6 +66,7 @@ class TestDesktopCommandBinder(unittest.TestCase):
         self.assertEqual(ui.read_response_now_button.calls[-1], {"state": "disabled"})
         self.assertEqual(ui.summarize_button.calls[-1], {"state": "disabled"})
         self.assertEqual(len(tooltip_calls), 4)
+        self.assertEqual(tooltip_calls[0][1]["font"], ("Arial", 12))
 
 
 if __name__ == "__main__":

--- a/app/transcribe/tests/test_desktop_display.py
+++ b/app/transcribe/tests/test_desktop_display.py
@@ -90,6 +90,15 @@ class TestDesktopDisplayManager(unittest.TestCase):
             ],
         )
 
+    def test_replace_display_line_text_preserves_timestamp(self):
+        updated = self.manager._replace_display_line_text(
+            "Speaker: [14:05:06] [old text]",
+            "Speaker",
+            "new text",
+        )
+
+        self.assertEqual(updated, "Speaker: [14:05:06] [new text]")
+
     def test_write_response_text_updates_textbox_state(self):
         self.manager.write_response_text("response text")
 

--- a/app/transcribe/tests/test_desktop_view.py
+++ b/app/transcribe/tests/test_desktop_view.py
@@ -1,0 +1,52 @@
+"""Unit tests for desktop view construction helpers."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.transcribe.desktop.view import DesktopViewBuilder
+
+
+class FakeMenu:
+    """Menu double that captures construction options and cascade entries."""
+
+    created = []
+
+    def __init__(self, master=None, **kwargs):
+        self.master = master
+        self.kwargs = kwargs
+        self.cascades = []
+        self.__class__.created.append(self)
+
+    def add_cascade(self, **kwargs):
+        self.cascades.append(kwargs)
+
+
+class TestDesktopViewBuilder(unittest.TestCase):
+    def setUp(self):
+        FakeMenu.created = []
+        self.builder = DesktopViewBuilder()
+        self.ui = SimpleNamespace(
+            ui_font_size=20,
+            option_add_calls=[],
+            config_calls=[],
+            option_add=lambda pattern, value: self.ui.option_add_calls.append((pattern, value)),
+            config=lambda **kwargs: self.ui.config_calls.append(kwargs),
+        )
+
+    def test_create_menus_uses_menu_font(self):
+        with patch("app.transcribe.desktop.view.tk.Menu", FakeMenu):
+            self.builder.create_menus(self.ui)
+
+        menu_font = ("Arial", 12)
+        self.assertEqual(self.ui.option_add_calls, [("*Menu.font", menu_font)])
+        self.assertEqual([menu.kwargs["font"] for menu in FakeMenu.created], [menu_font] * 4)
+        self.assertEqual(
+            [cascade["label"] for cascade in self.ui.menubar.cascades],
+            ["File", "Edit", "Help"],
+        )
+        self.assertEqual(self.ui.config_calls, [{"menu": self.ui.menubar}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/transcribe/tests/test_diarization.py
+++ b/app/transcribe/tests/test_diarization.py
@@ -1,0 +1,128 @@
+"""Unit tests for optional diarization helpers."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+from app.transcribe.diarization import (
+    DiarizationTurn,
+    PyannoteDiarizationService,
+    annotate_hypothesis_with_turns,
+    create_diarization_service,
+)
+from sdk.transcription_result import TranscriptSegment, TranscriptionHypothesis
+
+
+class TestDiarizationHelpers(unittest.TestCase):
+    def test_create_diarization_service_defaults_to_disabled(self):
+        service = create_diarization_service({})
+
+        self.assertFalse(service.enabled)
+
+    def test_annotate_hypothesis_assigns_largest_overlap_speaker(self):
+        hypothesis = TranscriptionHypothesis(
+            provider="test",
+            text="first second",
+            segments=[
+                TranscriptSegment(0, 0.0, 1.0, "first"),
+                TranscriptSegment(1, 1.0, 2.0, "second"),
+            ],
+            audio_start_seconds=0.0,
+            audio_end_seconds=2.0,
+        )
+        turns = [
+            DiarizationTurn(0.0, 1.2, "SPEAKER_00"),
+            DiarizationTurn(1.2, 2.0, "SPEAKER_01"),
+        ]
+
+        annotated = annotate_hypothesis_with_turns(hypothesis, turns)
+
+        self.assertEqual([segment.speaker for segment in annotated.segments], ["SPEAKER_00", "SPEAKER_01"])
+        self.assertEqual(hypothesis.segments[0].speaker, None)
+
+    def test_pyannote_warm_up_loads_pipeline(self):
+        class FakePyannoteService(PyannoteDiarizationService):
+            def __init__(self):
+                super().__init__()
+                self.load_count = 0
+
+            def _get_pipeline(self):
+                self.load_count += 1
+                return object()
+
+        service = FakePyannoteService()
+
+        service.warm_up()
+
+        self.assertEqual(service.load_count, 1)
+
+    def test_pyannote_diarize_passes_preloaded_audio_to_pipeline(self):
+        class FakeSegment:
+            start = 0.0
+            end = 1.0
+
+        class FakeAnnotation:
+            def __init__(self, speaker):
+                self.speaker = speaker
+
+            def itertracks(self, yield_label=False):
+                yield FakeSegment(), None, self.speaker
+
+        class FakeDiarizationOutput:
+            speaker_diarization = FakeAnnotation("SPEAKER_00")
+            exclusive_speaker_diarization = FakeAnnotation("SPEAKER_01")
+
+        class FakePipeline:
+            def __init__(self):
+                self.input = None
+
+            def __call__(self, audio):
+                self.input = audio
+                return FakeDiarizationOutput()
+
+        class FakePyannoteService(PyannoteDiarizationService):
+            def __init__(self, pipeline):
+                super().__init__()
+                self.pipeline = pipeline
+
+            def _get_pipeline(self):
+                return self.pipeline
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            wav_path = Path(temp_dir) / "sample.wav"
+            sf.write(wav_path, np.zeros(1600, dtype=np.float32), 16000)
+            pipeline = FakePipeline()
+            service = FakePyannoteService(pipeline)
+
+            turns = service.diarize(str(wav_path), audio_start_seconds=5.0)
+
+        self.assertIn("waveform", pipeline.input)
+        self.assertIn("sample_rate", pipeline.input)
+        self.assertEqual(pipeline.input["sample_rate"], 16000)
+        self.assertEqual(turns, [DiarizationTurn(5.0, 6.0, "SPEAKER_01")])
+
+    def test_extract_annotation_supports_legacy_annotation_output(self):
+        class FakeAnnotation:
+            def itertracks(self, yield_label=False):
+                return iter(())
+
+        annotation = FakeAnnotation()
+
+        self.assertIs(PyannoteDiarizationService._extract_annotation(annotation), annotation)
+
+    def test_load_audio_returns_channel_first_waveform(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            wav_path = Path(temp_dir) / "sample.wav"
+            sf.write(wav_path, np.zeros((1600, 2), dtype=np.float32), 16000)
+
+            audio = PyannoteDiarizationService._load_audio(str(wav_path))
+
+        self.assertEqual(audio["sample_rate"], 16000)
+        self.assertEqual(tuple(audio["waveform"].shape), (2, 1600))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/transcribe/tests/test_live_transcription.py
+++ b/app/transcribe/tests/test_live_transcription.py
@@ -90,6 +90,35 @@ class TestLiveTranscriptManager(unittest.TestCase):
         self.assertEqual(update.text.count("Which is a little bit annoying"), 1)
         self.assertEqual(update.text.count("So normally what you do against Zerg"), 1)
 
+    def test_repeated_sentence_hallucination_is_collapsed(self):
+        update = self.manager.process_hypothesis(
+            "Speaker",
+            hypothesis(
+                "I'm just a little bit more careful. "
+                "I'm just a little bit more careful. "
+                "I'm just a little bit more careful. "
+                "I'm not going to let you go. "
+                "I'm not going to let you go. "
+                "I'm not going to let you go."
+            ),
+            new_phrase=True,
+        )
+
+        self.assertEqual(update.text.count("I'm just a little bit more careful."), 1)
+        self.assertEqual(update.text.count("I'm not going to let you go."), 1)
+
+    def test_repeated_token_phrase_hallucination_is_collapsed(self):
+        update = self.manager.process_hypothesis(
+            "You",
+            hypothesis(
+                "I'm going to get a little bit of a little bit of a little bit of "
+                "a little bit of rest."
+            ),
+            new_phrase=True,
+        )
+
+        self.assertEqual(update.text, "I'm going to get a little bit of rest.")
+
     def test_mutable_tail_correction_updates_current_text(self):
         self.manager.process_hypothesis(
             "You",

--- a/app/transcribe/tests/test_provider_stt.py
+++ b/app/transcribe/tests/test_provider_stt.py
@@ -88,6 +88,8 @@ class TestSTTProviders(unittest.TestCase):
             set_transcriber=MagicMock(),
         )
         transcriber_instance = MagicMock()
+        transcriber_instance.supports_diarization = True
+        transcriber_instance.diarization_service.enabled = False
         mock_transcriber.return_value = transcriber_instance
         mock_create_stt_model.return_value = "model"
 
@@ -114,6 +116,8 @@ class TestSTTProviders(unittest.TestCase):
             set_transcriber=MagicMock(),
         )
         transcriber_instance = MagicMock()
+        transcriber_instance.supports_diarization = True
+        transcriber_instance.diarization_service.enabled = False
         mock_transcriber.return_value = transcriber_instance
         mock_create_stt_model.return_value = "model"
 
@@ -126,6 +130,30 @@ class TestSTTProviders(unittest.TestCase):
 
         kwargs = mock_transcriber.call_args.kwargs
         self.assertNotIn("audio_chunk_preprocessor", kwargs)
+
+    @patch("app.transcribe.providers.stt.WhisperTranscriber")
+    @patch("app.transcribe.providers.stt.create_stt_model")
+    def test_create_transcriber_warms_up_enabled_diarization(self, mock_create_stt_model, mock_transcriber):
+        runtime = SimpleNamespace(
+            user_audio_recorder=SimpleNamespace(source="mic"),
+            speaker_audio_recorder=SimpleNamespace(source="speaker"),
+            convo="conversation",
+            set_transcriber=MagicMock(),
+        )
+        transcriber_instance = MagicMock()
+        transcriber_instance.supports_diarization = True
+        transcriber_instance.diarization_service.enabled = True
+        mock_transcriber.return_value = transcriber_instance
+        mock_create_stt_model.return_value = "model"
+
+        stt.create_transcriber(
+            name="whisper",
+            config={"General": {}, "OpenAI": {}},
+            api=False,
+            runtime=runtime,
+        )
+
+        transcriber_instance.diarization_service.warm_up.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/docs/Diarization.md
+++ b/docs/Diarization.md
@@ -1,0 +1,38 @@
+# Optional Speaker Diarization
+
+Transcribe can optionally label speakers within Whisper and whisper.cpp transcripts using pyannote.audio.
+
+This feature is disabled by default because it adds a larger PyTorch-based dependency stack and requires access to a Hugging Face diarization model.
+
+## Install
+
+Run the normal setup first, then install the optional diarization dependencies:
+
+```powershell
+app\transcribe\setup-diarization.bat
+```
+
+The diarization setup reinstalls CUDA-enabled PyTorch wheels after installing pyannote, because pyannote's dependency resolution can otherwise leave the environment with CPU-only Torch.
+
+## Configure
+
+Accept the model terms on Hugging Face for the configured pyannote model, create a Hugging Face access token, and set it as an environment variable:
+
+```powershell
+$env:HUGGINGFACE_TOKEN = "your-token"
+```
+
+Then enable diarization in `app\transcribe\override.yaml`:
+
+```yaml
+Diarization:
+  enabled: True
+```
+
+The default model is `pyannote/speaker-diarization-community-1`.
+
+## Behavior
+
+When enabled, Whisper and whisper.cpp transcript segments are aligned with pyannote speaker turns. Transcribe displays source-specific speaker labels such as `Speaker 1`, `Speaker 2`, `You 1`, and `You 2`.
+
+Speaker labels are assigned independently for microphone and speaker-output audio streams.

--- a/sdk/transcriber_models.py
+++ b/sdk/transcriber_models.py
@@ -306,7 +306,8 @@ class WhisperSTTModel(STTModelInterface):
         result = self.audio_model.transcribe(wav_file_path,
                                              fp16=False,
                                              language=self.lang,
-                                             temperature=0)
+                                             temperature=0,
+                                             condition_on_previous_text=False)
         sentences = []
         for segment in result['segments']:
             start = str(datetime.timedelta(seconds=int(segment['start'])))
@@ -324,7 +325,8 @@ class WhisperSTTModel(STTModelInterface):
             result = self.audio_model.transcribe(wav_file_path,
                                                  fp16=False,
                                                  language=self.lang,
-                                                 temperature=0)
+                                                 temperature=0,
+                                                 condition_on_previous_text=False)
         except Exception as exception:
             print('WhisperSTTModel:get_transcription - Encountered error')
             print(exception)

--- a/sdk/transcription_result.py
+++ b/sdk/transcription_result.py
@@ -14,6 +14,7 @@ class TranscriptSegment:
     end_seconds: float
     text: str
     confidence: float | None = None
+    speaker: str | None = None
 
 
 @dataclass(frozen=True)

--- a/setup.bat
+++ b/setup.bat
@@ -2,7 +2,7 @@ python --version
 python -m venv venv
 call venv\scripts\activate.bat
 python -m pip install --upgrade pip
-python -m pip install torch --index-url https://download.pytorch.org/whl/cu121
+python -m pip install torch==2.11.0+cu126 torchaudio==2.11.0+cu126 --index-url https://download.pytorch.org/whl/cu126
 cd app\transcribe
 python -m pip install -r requirements.txt
 python -m pip install pytest


### PR DESCRIPTION
## Summary

Adds optional pyannote-based speaker diarization for Whisper and whisper.cpp, along with transcript display updates for timestamps and UI text sizing.

## Details

- Adds a provider-independent diarization service with pyannote support.
- Labels diarized transcript segments as source-specific speakers such as `Speaker 1` and `You 1`.
- Keeps diarization optional through separate requirements and setup files.
- Adds local-time transcript timestamps in the transcription window.
- Adjusts menu and tooltip font sizing for consistency.
- Reduces repeated Whisper hallucinations in rolling live transcription by disabling previous-text conditioning and collapsing repeated phrases.
- Updates CUDA setup guidance/scripts for Python 3.13 and optional diarization.

## Validation

- `python -m unittest discover app\transcribe\tests -v`
- Result: 83 passed, 5 optional smoke tests skipped.

## Notes

`app/transcribe/override.yaml` is not included in this PR.