### PR TITLE
Add optional OpenAI Realtime transcription backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Transcribe provides real time transcription for microphone and speaker output. I
     - Offline - FREE
     - Online - paid
       - OpenAI Whisper - **(Encouraged)**
+      - OpenAI Realtime (`gpt-live-transcribe`)
       - Deepgram
 - Chat Inference Engines
     - OpenAI
@@ -84,6 +85,7 @@ Connect on LinkedIn to discuss further.
 - [Save Content](./docs/SaveContent.md)
 - [Model Selection](./docs/ModelSelection.md)
 - [Experimental SenseVoiceSmall backend](./docs/SenseVoice.md)
+- [OpenAI Realtime transcription](./docs/OpenAIRealtime.md)
 - [Batch Operations](./docs/BatchOperations.md)
 - [Application Configuration](./docs/AppConfig.md)
 - [OpenAI API Compatible Provider Support](./docs/Providers.md)
@@ -217,6 +219,14 @@ Run the main script from `app\transcribe\` folder:
 ```
 python main.py
 ```
+
+To use native low-latency OpenAI streaming transcription instead of the default local Whisper backend:
+
+```powershell
+python main.py -stt openai-realtime
+```
+
+This mode requires an OpenAI API key and API billing, which is separate from a ChatGPT subscription. Microphone and Windows speaker loopback audio use independent sessions and remain labeled `You` and `Speaker`. See [OpenAI Realtime transcription](./docs/OpenAIRealtime.md) for configuration, costs, privacy, consent, and limitations.
 
 Upon initiation, Transcribe will begin transcribing microphone input and speaker output in real-time, optionally generating a suggested response based on the conversation. It is suggested to use continuous response feature after 1-2 minutes, once there is enough content in transcription window to provide enough context to the LLM.
 

--- a/app/transcribe/audio_transcriber.py
+++ b/app/transcribe/audio_transcriber.py
@@ -18,6 +18,7 @@ from .live_transcription import (
     DEFAULT_WINDOW_SECONDS,
     LiveTranscriptManager,
 )
+from .transcriber import TranscriberInterface
 import custom_speech_recognition as sr
 from tsutils import app_logging as al
 from tsutils import duration
@@ -35,7 +36,7 @@ WHISPER_SEGMENT_PRUNE_THRESHOLD = 6
 AUDIO_LENGTH_PRUNE_THRESHOLD_SECONDS = 45
 
 
-class AudioTranscriber:   # pylint: disable=C0115, R0902
+class AudioTranscriber(TranscriberInterface):   # pylint: disable=C0115, R0902
 
     def __init__(self, mic_source, speaker_source, model,
                  convo: conversation.Conversation,
@@ -118,6 +119,21 @@ class AudioTranscriber:   # pylint: disable=C0115, R0902
             self.audio_sources_properties['Speaker']['sample_rate'] = speaker_source.SAMPLE_RATE
             self.audio_sources_properties['Speaker']['sample_width'] = speaker_source.SAMPLE_WIDTH
             self.audio_sources_properties['Speaker']['channels'] = speaker_source.channels
+
+    def set_source_enabled(self, source_name: str, enabled: bool):
+        """File/window providers do not own source capture resources."""
+        del source_name, enabled
+
+    def set_transcription_enabled(self, enabled: bool):
+        """Pause or resume transcription without changing capture resources."""
+        self.transcribe = bool(enabled)
+
+    def set_language(self, lang: str):
+        """Update the language on the configured file/window STT model."""
+        self.stt_model.set_lang(lang)
+
+    def stop(self):
+        """File/window transcribers own no persistent provider resources."""
 
     def transcribe_audio_queue(self, audio_queue: queue.Queue):
         """Transcribe data from audio sources. In this case we have 2 sources, microphone, speaker.

--- a/app/transcribe/cli/arguments.py
+++ b/app/transcribe/cli/arguments.py
@@ -27,7 +27,7 @@ def create_args() -> argparse.Namespace:
         "--speech_to_text",
         action="store",
         default=None,
-        choices=["whisper", "whisper.cpp", "deepgram", "sensevoice"],
+        choices=["whisper", "whisper.cpp", "deepgram", "sensevoice", "openai-realtime"],
         help="Specify the Speech to text Engine.\nLocal STT models tend to perform best for response times.\nAPI based STT models tend to perform best for accuracy.",
     )
     cmd_args.add_argument(

--- a/app/transcribe/core/conversation.py
+++ b/app/transcribe/core/conversation.py
@@ -31,16 +31,20 @@ class Conversation:
         self.last_update: datetime.datetime | None = None
         self.update_handler = None
         self.insert_handler = None
+        self.partial_handler = None
+        self.finalize_partial_handler = None
         self.context = context
         self._initialized = False
         self._lock = threading.RLock()
         self.initialize_conversation()
 
-    def set_handlers(self, update, insert):
+    def set_handlers(self, update, insert, partial=None, finalize_partial=None):
         """Set callback handlers for update and insert events."""
         with self._lock:
             self.update_handler = update
             self.insert_handler = insert
+            self.partial_handler = partial
+            self.finalize_partial_handler = finalize_partial
 
     def initialize_conversation(self):
         """Populate the initial system prompt and seed conversation."""
@@ -103,6 +107,7 @@ class Conversation:
         time_spoken,
         update_previous: bool = False,
         replace_ui_partial: bool = False,
+        partial_id: str | None = None,
     ):
         """Insert or update a conversation fragment in memory and the database."""
         callback = None
@@ -145,7 +150,10 @@ class Conversation:
                     and convo_object is not None
                 ):
                     convo_id = convo_object.insert_conversation(inv_id, time_spoken, persona, text)
-                    if replace_ui_partial and self.update_handler is not None:
+                    if replace_ui_partial and partial_id and self.finalize_partial_handler is not None:
+                        callback = self.finalize_partial_handler
+                        callback_args = (partial_id, ui_text)
+                    elif replace_ui_partial and self.update_handler is not None:
                         callback = self.update_handler
                         callback_args = (persona, ui_text)
                     elif self.insert_handler is not None:
@@ -158,14 +166,24 @@ class Conversation:
         if callback is not None:
             callback(*callback_args)
 
-    def publish_partial(self, persona: str, text: str, update_previous: bool = False):
+    def publish_partial(
+        self,
+        persona: str,
+        text: str,
+        update_previous: bool = False,
+        partial_id: str | None = None,
+    ):
         """Render volatile provider text without adding it to memory or the database."""
         with self._lock:
-            callback = self.update_handler if update_previous else self.insert_handler
+            callback = self.partial_handler if partial_id else (
+                self.update_handler if update_previous else self.insert_handler
+            )
         if callback is None:
             return False
         ui_text = f"{persona}: [{text}]\n"
-        if update_previous:
+        if partial_id:
+            callback(partial_id, ui_text)
+        elif update_previous:
             callback(persona, ui_text)
         else:
             callback(ui_text)

--- a/app/transcribe/core/conversation.py
+++ b/app/transcribe/core/conversation.py
@@ -102,6 +102,7 @@ class Conversation:
         text: str,
         time_spoken,
         update_previous: bool = False,
+        replace_ui_partial: bool = False,
     ):
         """Insert or update a conversation fragment in memory and the database."""
         callback = None
@@ -144,7 +145,10 @@ class Conversation:
                     and convo_object is not None
                 ):
                     convo_id = convo_object.insert_conversation(inv_id, time_spoken, persona, text)
-                    if self.insert_handler is not None:
+                    if replace_ui_partial and self.update_handler is not None:
+                        callback = self.update_handler
+                        callback_args = (persona, ui_text)
+                    elif self.insert_handler is not None:
                         callback = self.insert_handler
                         callback_args = (ui_text,)
 
@@ -153,6 +157,19 @@ class Conversation:
 
         if callback is not None:
             callback(*callback_args)
+
+    def publish_partial(self, persona: str, text: str, update_previous: bool = False):
+        """Render volatile provider text without adding it to memory or the database."""
+        with self._lock:
+            callback = self.update_handler if update_previous else self.insert_handler
+        if callback is None:
+            return False
+        ui_text = f"{persona}: [{text}]\n"
+        if update_previous:
+            callback(persona, ui_text)
+        else:
+            callback(ui_text)
+        return True
 
     def get_convo_id(self, persona: str, input_text: str):
         """Retrieve the persisted id for a conversation row."""

--- a/app/transcribe/core/state.py
+++ b/app/transcribe/core/state.py
@@ -15,7 +15,7 @@ from sdk import audio_recorder as ar
 
 if TYPE_CHECKING:
     from ..audio_player import AudioPlayer
-    from ..audio_transcriber import AudioTranscriber
+    from ..transcriber import TranscriberInterface
 
 
 class AppRuntime:
@@ -25,7 +25,7 @@ class AppRuntime:
     user_audio_recorder: ar.MicRecorder = None
     speaker_audio_recorder: ar.SpeakerRecorder = None
     audio_player_var: "AudioPlayer" = None
-    transcriber: "AudioTranscriber" = None
+    transcriber: "TranscriberInterface" = None
     responder = None
     update_response_now: bool = False
     read_response: bool = False

--- a/app/transcribe/desktop/controller.py
+++ b/app/transcribe/desktop/controller.py
@@ -115,11 +115,10 @@ class DesktopController:
         """Toggle speaker capture state."""
         try:
             self.global_vars.speaker_audio_recorder.enabled = not self.global_vars.speaker_audio_recorder.enabled
-            if hasattr(self.global_vars.transcriber, "set_source_enabled"):
-                self.global_vars.transcriber.set_source_enabled(
-                    "Speaker",
-                    self.global_vars.speaker_audio_recorder.enabled,
-                )
+            self.global_vars.transcriber.set_source_enabled(
+                constants.PERSONA_SPEAKER,
+                self.global_vars.speaker_audio_recorder.enabled,
+            )
             self.presenter.set_speaker_enabled(self.global_vars.speaker_audio_recorder.enabled)
             self.capture_action(
                 f'{"Enabled " if self.global_vars.speaker_audio_recorder.enabled else "Disabled "} speaker input'
@@ -131,11 +130,10 @@ class DesktopController:
         """Toggle microphone capture state."""
         try:
             self.global_vars.user_audio_recorder.enabled = not self.global_vars.user_audio_recorder.enabled
-            if hasattr(self.global_vars.transcriber, "set_source_enabled"):
-                self.global_vars.transcriber.set_source_enabled(
-                    "You",
-                    self.global_vars.user_audio_recorder.enabled,
-                )
+            self.global_vars.transcriber.set_source_enabled(
+                constants.PERSONA_YOU,
+                self.global_vars.user_audio_recorder.enabled,
+            )
             self.presenter.set_microphone_enabled(self.global_vars.user_audio_recorder.enabled)
             self.capture_action(
                 f'{"Enabled " if self.global_vars.user_audio_recorder.enabled else "Disabled "} microphone input'
@@ -240,11 +238,8 @@ class DesktopController:
         """Toggle transcription capture state."""
         logger.info(f"{self.__class__.__name__}.set_transcript_state")
         try:
-            self.global_vars.transcriber.transcribe = not self.global_vars.transcriber.transcribe
-            if hasattr(self.global_vars.transcriber, "set_transcription_enabled"):
-                self.global_vars.transcriber.set_transcription_enabled(
-                    self.global_vars.transcriber.transcribe
-                )
+            enabled = not self.global_vars.transcriber.transcribe
+            self.global_vars.transcriber.set_transcription_enabled(enabled)
             self.capture_action(
                 f'{"Enabled " if self.global_vars.transcriber.transcribe else "Disabled "} transcription.'
             )
@@ -282,7 +277,7 @@ class DesktopController:
         try:
             self.settings_service.save_audio_language(
                 lang=lang,
-                stt_model=self.global_vars.transcriber.stt_model,
+                transcriber=self.global_vars.transcriber,
             )
         except Exception as exception:
             logger.error(f"Error setting audio language: {exception}")

--- a/app/transcribe/desktop/controller.py
+++ b/app/transcribe/desktop/controller.py
@@ -115,6 +115,11 @@ class DesktopController:
         """Toggle speaker capture state."""
         try:
             self.global_vars.speaker_audio_recorder.enabled = not self.global_vars.speaker_audio_recorder.enabled
+            if hasattr(self.global_vars.transcriber, "set_source_enabled"):
+                self.global_vars.transcriber.set_source_enabled(
+                    "Speaker",
+                    self.global_vars.speaker_audio_recorder.enabled,
+                )
             self.presenter.set_speaker_enabled(self.global_vars.speaker_audio_recorder.enabled)
             self.capture_action(
                 f'{"Enabled " if self.global_vars.speaker_audio_recorder.enabled else "Disabled "} speaker input'
@@ -126,6 +131,11 @@ class DesktopController:
         """Toggle microphone capture state."""
         try:
             self.global_vars.user_audio_recorder.enabled = not self.global_vars.user_audio_recorder.enabled
+            if hasattr(self.global_vars.transcriber, "set_source_enabled"):
+                self.global_vars.transcriber.set_source_enabled(
+                    "You",
+                    self.global_vars.user_audio_recorder.enabled,
+                )
             self.presenter.set_microphone_enabled(self.global_vars.user_audio_recorder.enabled)
             self.capture_action(
                 f'{"Enabled " if self.global_vars.user_audio_recorder.enabled else "Disabled "} microphone input'
@@ -231,6 +241,10 @@ class DesktopController:
         logger.info(f"{self.__class__.__name__}.set_transcript_state")
         try:
             self.global_vars.transcriber.transcribe = not self.global_vars.transcriber.transcribe
+            if hasattr(self.global_vars.transcriber, "set_transcription_enabled"):
+                self.global_vars.transcriber.set_transcription_enabled(
+                    self.global_vars.transcriber.transcribe
+                )
             self.capture_action(
                 f'{"Enabled " if self.global_vars.transcriber.transcribe else "Disabled "} transcription.'
             )

--- a/app/transcribe/desktop/display.py
+++ b/app/transcribe/desktop/display.py
@@ -34,7 +34,12 @@ class DesktopDisplayManager:
             self.ui.update_interval_slider,
             runtime,
         )
-        runtime.convo.set_handlers(self.queue_update_last_row, self.queue_add_transcript_line)
+        runtime.convo.set_handlers(
+            self.queue_update_last_row,
+            self.queue_add_transcript_line,
+            partial=self.queue_upsert_partial_row,
+            finalize_partial=self.queue_finalize_partial_row,
+        )
 
     def update_last_row(self, speaker: str, input_text: str):
         """Replace the latest transcript row for a speaker."""
@@ -51,6 +56,14 @@ class DesktopDisplayManager:
     def queue_add_transcript_line(self, input_text: str):
         """Queue transcript insertion on the Tk thread."""
         self.ui.enqueue_ui_action(self.ui.transcript_text.add_text_to_bottom, input_text)
+
+    def queue_upsert_partial_row(self, item_id: str, input_text: str):
+        """Queue insertion or replacement of one provider-addressed partial row."""
+        self.ui.enqueue_ui_action(self.ui.transcript_text.upsert_keyed_row, item_id, input_text)
+
+    def queue_finalize_partial_row(self, item_id: str, input_text: str):
+        """Queue replacement of a provider partial with its durable final text."""
+        self.ui.enqueue_ui_action(self.ui.transcript_text.finalize_keyed_row, item_id, input_text)
 
     def write_response_text(self, response_string: str):
         """Render a response string into the response textbox."""

--- a/app/transcribe/desktop/runtime.py
+++ b/app/transcribe/desktop/runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import queue
 import threading
 import time
 
@@ -18,6 +19,9 @@ def initialize_desktop_runtime(runtime, config: dict):
     """Initialize the desktop runtime state without launching the UI."""
     ensure_ffmpeg_available()
     initiate_db(runtime)
+    if config["General"]["stt"].lower() == "openai-realtime":
+        max_chunks = max(2, int(config.get("OpenAIRealtime", {}).get("max_raw_audio_chunks", 240)))
+        runtime.audio_queue = queue.Queue(maxsize=max_chunks)
     runtime.initiate_audio_devices(config)
     create_transcriber(
         name=config["General"]["stt"],
@@ -126,7 +130,7 @@ def initiate_db(runtime):
 
 def shutdown(runtime):
     """Activities to be performed right before application shutdown."""
-    if runtime.transcriber is not None and hasattr(runtime.transcriber, "stop"):
+    if runtime.transcriber is not None:
         runtime.transcriber.stop()
     for recorder in (runtime.user_audio_recorder, runtime.speaker_audio_recorder):
         if recorder is not None and recorder.stop_record_func is not None:

--- a/app/transcribe/desktop/runtime.py
+++ b/app/transcribe/desktop/runtime.py
@@ -126,6 +126,11 @@ def initiate_db(runtime):
 
 def shutdown(runtime):
     """Activities to be performed right before application shutdown."""
+    if runtime.transcriber is not None and hasattr(runtime.transcriber, "stop"):
+        runtime.transcriber.stop()
+    for recorder in (runtime.user_audio_recorder, runtime.speaker_audio_recorder):
+        if recorder is not None and recorder.stop_record_func is not None:
+            recorder.stop_record_func(wait_for_stop=True)
     runtime.user_audio_recorder.write_wav_data_to_file()
     runtime.speaker_audio_recorder.write_wav_data_to_file()
     AppDB().shutdown_app()

--- a/app/transcribe/desktop/services.py
+++ b/app/transcribe/desktop/services.py
@@ -59,9 +59,9 @@ class SettingsService:
         config_obj.add_override_value({"General": {"llm_response_interval": interval}})
         return interval
 
-    def save_audio_language(self, lang: str, stt_model):
+    def save_audio_language(self, lang: str, transcriber):
         """Persist the STT language and update the live model."""
-        stt_model.set_lang(lang)
+        transcriber.set_language(lang)
         config_obj = self.config_factory()
         config_obj.add_override_value({"OpenAI": {"audio_lang": lang}})
 

--- a/app/transcribe/main.py
+++ b/app/transcribe/main.py
@@ -53,7 +53,7 @@ def main():
     print("READY")
 
     # Set the response lang in STT Model.
-    runtime.transcriber.stt_model.set_lang(config['OpenAI']['audio_lang'])
+    runtime.transcriber.set_language(config['OpenAI']['audio_lang'])
     aui.update_initial_transcripts()
     aui.start()
     log_listener.stop()

--- a/app/transcribe/openai_realtime_transcriber.py
+++ b/app/transcribe/openai_realtime_transcriber.py
@@ -5,17 +5,20 @@ from __future__ import annotations
 import datetime
 import queue
 import threading
+from collections import deque
 
-from sdk.streaming_transcriber_models import OpenAIRealtimeSTTModel
+from sdk.streaming_transcriber_models import StreamingTranscriptEvent, TranscriptEventKind
 
 from . import constants
+from .providers.openai_realtime import OpenAIRealtimeSTTModel
+from .transcriber import TranscriberInterface
 from tsutils import app_logging as al
 
 
 logger = al.get_module_logger(al.TRANSCRIBER_LOGGER)
 
 
-class OpenAIRealtimeTranscriber:
+class OpenAIRealtimeTranscriber(TranscriberInterface):
     """Route microphone and loopback PCM to separate persistent STT sessions."""
 
     def __init__(
@@ -28,7 +31,6 @@ class OpenAIRealtimeTranscriber:
     ):
         self.config = config
         self.conversation = convo
-        self.stt_model = self  # compatibility with language controls used by the desktop runtime
         self.supports_diarization = False
         self.transcript_changed_event = threading.Event()
         self.transcribe = True
@@ -38,12 +40,21 @@ class OpenAIRealtimeTranscriber:
         self._result_queue: queue.Queue = queue.Queue(
             maxsize=max(10, int(config.get("OpenAIRealtime", {}).get("event_queue_size", 500)))
         )
+        self._completed_queue: queue.Queue = queue.Queue()
         self._partial_items: dict[tuple[str, str], str] = {}
         self._completed_items: set[tuple[str, str]] = set()
-        self._source_enabled = {"You": True, "Speaker": True}
+        self._completed_item_order: deque[tuple[str, str]] = deque()
+        self._deduplication_cache_size = max(
+            1,
+            int(config.get("OpenAIRealtime", {}).get("deduplication_cache_size", 2048)),
+        )
+        self._source_enabled = {
+            constants.PERSONA_YOU: True,
+            constants.PERSONA_SPEAKER: True,
+        }
         self._source_formats = {
-            "You": self._source_format(mic_source),
-            "Speaker": self._source_format(speaker_source),
+            constants.PERSONA_YOU: self._source_format(mic_source),
+            constants.PERSONA_SPEAKER: self._source_format(speaker_source),
         }
 
         realtime_config = dict(config.get("OpenAIRealtime", {}))
@@ -58,8 +69,7 @@ class OpenAIRealtimeTranscriber:
             for source_name, source_format in self._source_formats.items()
         }
         for client in self.clients.values():
-            client.set_partial_callback(self._queue_partial)
-            client.set_completed_callback(self._queue_completed)
+            client.set_transcript_callback(self._queue_transcript_event)
             client.set_error_callback(self._queue_error)
 
     @staticmethod
@@ -82,7 +92,10 @@ class OpenAIRealtimeTranscriber:
 
     def set_source_properties(self, mic_source=None, speaker_source=None):
         """Keep each session's converter aligned with its real capture device."""
-        updates = {"You": mic_source, "Speaker": speaker_source}
+        updates = {
+            constants.PERSONA_YOU: mic_source,
+            constants.PERSONA_SPEAKER: speaker_source,
+        }
         for source_name, source in updates.items():
             if source is None:
                 continue
@@ -90,7 +103,7 @@ class OpenAIRealtimeTranscriber:
             self._source_formats[source_name] = source_format
             self.clients[source_name].configure_source(source_format)
 
-    def set_lang(self, lang: str):
+    def set_language(self, lang: str):
         """Update expected input language on both active sessions."""
         languages = [self._language_code(lang)]
         for client in self.clients.values():
@@ -102,14 +115,14 @@ class OpenAIRealtimeTranscriber:
         while not self._stop_event.is_set():
             self._drain_result_queue()
             try:
-                who_spoke, data, _time_spoken = audio_queue.get(timeout=0.05)
+                who_spoke, data, time_spoken = audio_queue.get(timeout=0.05)
             except queue.Empty:
                 continue
 
             if self.transcribe and self._source_enabled.get(who_spoke, False):
                 try:
-                    self.clients[who_spoke].append_audio(data)
-                except Exception as exception:
+                    self.clients[who_spoke].append_audio(data, captured_at=time_spoken)
+                except (KeyError, TypeError, ValueError) as exception:
                     self._queue_error(who_spoke, f"Could not process source audio: {exception}")
             self._drain_result_queue()
 
@@ -158,7 +171,9 @@ class OpenAIRealtimeTranscriber:
         """Clear confirmed, partial, queued, and server-side uncommitted state."""
         self._partial_items.clear()
         self._completed_items.clear()
+        self._completed_item_order.clear()
         self._drain_queue(self._result_queue)
+        self._drain_queue(self._completed_queue)
         with audio_queue.mutex:
             audio_queue.queue.clear()
         for client in self.clients.values():
@@ -172,16 +187,16 @@ class OpenAIRealtimeTranscriber:
             if self._source_enabled[source_name]:
                 client.start()
 
-    def _queue_partial(self, source_name: str, item_id: str, text: str):
-        self._put_result(("partial", source_name, item_id, text, datetime.datetime.utcnow()))
-
-    def _queue_completed(self, source_name: str, item_id: str, text: str):
-        self._put_result(("completed", source_name, item_id, text, datetime.datetime.utcnow()), final=True)
+    def _queue_transcript_event(self, event: StreamingTranscriptEvent):
+        if event.kind is TranscriptEventKind.COMPLETED:
+            self._completed_queue.put(event)
+        else:
+            self._put_result(event)
 
     def _queue_error(self, source_name: str, message: str):
-        self._put_result(("error", source_name, "", str(message), datetime.datetime.utcnow()), final=True)
+        self._put_result((source_name, str(message)), final=True)
 
-    def _put_result(self, event: tuple, final: bool = False):
+    def _put_result(self, event, final: bool = False):
         try:
             self._result_queue.put_nowait(event)
         except queue.Full:
@@ -196,42 +211,65 @@ class OpenAIRealtimeTranscriber:
     def _drain_result_queue(self):
         while True:
             try:
-                event_type, source_name, item_id, text, event_time = self._result_queue.get_nowait()
+                event = self._result_queue.get_nowait()
+            except queue.Empty:
+                break
+            if isinstance(event, StreamingTranscriptEvent):
+                self._handle_partial(event)
+            else:
+                source_name, message = event
+                logger.error("OpenAI Realtime (%s): %s", source_name, message)
+        self._drain_completed_queue()
+
+    def _drain_completed_queue(self):
+        while True:
+            try:
+                event = self._completed_queue.get_nowait()
             except queue.Empty:
                 return
-            if event_type == "partial":
-                self._handle_partial(source_name, item_id, text)
-            elif event_type == "completed":
-                self._handle_completed(source_name, item_id, text, event_time)
-            else:
-                logger.error("OpenAI Realtime (%s): %s", source_name, text)
+            self._handle_completed(event)
 
-    def _handle_partial(self, source_name: str, item_id: str, text: str):
-        key = (source_name, item_id)
-        if key in self._completed_items or not text.strip():
+    def _handle_partial(self, event: StreamingTranscriptEvent):
+        key = (event.source, event.item_id)
+        if key in self._completed_items or not event.text.strip():
             return
         update_previous = key in self._partial_items
         published = self.conversation.publish_partial(
-            persona=source_name,
-            text=text,
+            persona=event.source,
+            text=event.text,
             update_previous=update_previous,
+            partial_id=self._partial_id(event.source, event.item_id),
         )
         if published:
-            self._partial_items[key] = text
+            self._partial_items[key] = event.text
 
-    def _handle_completed(self, source_name: str, item_id: str, text: str, event_time):
-        key = (source_name, item_id)
-        if key in self._completed_items or not text.strip():
+    def _handle_completed(self, event: StreamingTranscriptEvent):
+        key = (event.source, event.item_id)
+        if key in self._completed_items or not event.text.strip():
             return
-        self._completed_items.add(key)
+        self._remember_completed(key)
         replace_ui_partial = self._partial_items.pop(key, None) is not None
         self.conversation.update_conversation(
-            persona=source_name,
-            text=text.strip(),
-            time_spoken=event_time,
+            persona=event.source,
+            text=event.text.strip(),
+            time_spoken=event.time_spoken or datetime.datetime.utcnow(),
             replace_ui_partial=replace_ui_partial,
+            partial_id=self._partial_id(event.source, event.item_id) if replace_ui_partial else None,
         )
         self.transcript_changed_event.set()
+
+    def _remember_completed(self, key: tuple[str, str]):
+        if key in self._completed_items:
+            return
+        if len(self._completed_item_order) >= self._deduplication_cache_size:
+            expired = self._completed_item_order.popleft()
+            self._completed_items.discard(expired)
+        self._completed_item_order.append(key)
+        self._completed_items.add(key)
+
+    @staticmethod
+    def _partial_id(source_name: str, item_id: str) -> str:
+        return f"{source_name}:{item_id}"
 
     @staticmethod
     def _drain_queue(target_queue: queue.Queue):

--- a/app/transcribe/openai_realtime_transcriber.py
+++ b/app/transcribe/openai_realtime_transcriber.py
@@ -1,0 +1,242 @@
+"""Application adapter for independent OpenAI Realtime audio sessions."""
+
+from __future__ import annotations
+
+import datetime
+import queue
+import threading
+
+from sdk.streaming_transcriber_models import OpenAIRealtimeSTTModel
+
+from . import constants
+from tsutils import app_logging as al
+
+
+logger = al.get_module_logger(al.TRANSCRIBER_LOGGER)
+
+
+class OpenAIRealtimeTranscriber:
+    """Route microphone and loopback PCM to separate persistent STT sessions."""
+
+    def __init__(
+        self,
+        mic_source,
+        speaker_source,
+        convo,
+        config: dict,
+        client_factory=OpenAIRealtimeSTTModel,
+    ):
+        self.config = config
+        self.conversation = convo
+        self.stt_model = self  # compatibility with language controls used by the desktop runtime
+        self.supports_diarization = False
+        self.transcript_changed_event = threading.Event()
+        self.transcribe = True
+        self.clear_transcript_periodically = bool(config["General"]["clear_transcript_periodically"])
+        self.clear_transcript_interval_seconds = int(config["General"]["clear_transcript_interval_seconds"])
+        self._stop_event = threading.Event()
+        self._result_queue: queue.Queue = queue.Queue(
+            maxsize=max(10, int(config.get("OpenAIRealtime", {}).get("event_queue_size", 500)))
+        )
+        self._partial_items: dict[tuple[str, str], str] = {}
+        self._completed_items: set[tuple[str, str]] = set()
+        self._source_enabled = {"You": True, "Speaker": True}
+        self._source_formats = {
+            "You": self._source_format(mic_source),
+            "Speaker": self._source_format(speaker_source),
+        }
+
+        realtime_config = dict(config.get("OpenAIRealtime", {}))
+        realtime_config["api_key"] = config.get("OpenAI", {}).get("api_key")
+        realtime_config["languages"] = [self._language_code(config["OpenAI"].get("audio_lang", "English"))]
+        self.clients = {
+            source_name: client_factory(
+                source_name=source_name,
+                source_format=source_format,
+                config=dict(realtime_config),
+            )
+            for source_name, source_format in self._source_formats.items()
+        }
+        for client in self.clients.values():
+            client.set_partial_callback(self._queue_partial)
+            client.set_completed_callback(self._queue_completed)
+            client.set_error_callback(self._queue_error)
+
+    @staticmethod
+    def _source_format(source) -> dict:
+        return {
+            "sample_rate": int(source.SAMPLE_RATE),
+            "sample_width": int(source.SAMPLE_WIDTH),
+            "channels": int(source.channels),
+        }
+
+    @staticmethod
+    def _language_code(lang: str) -> str:
+        from tsutils import language  # pylint: disable=import-outside-toplevel
+
+        normalized = str(lang or "").strip().lower()
+        for code, name in language.LANGUAGES_DICT.items():
+            if name == normalized:
+                return code
+        return normalized if normalized else "en"
+
+    def set_source_properties(self, mic_source=None, speaker_source=None):
+        """Keep each session's converter aligned with its real capture device."""
+        updates = {"You": mic_source, "Speaker": speaker_source}
+        for source_name, source in updates.items():
+            if source is None:
+                continue
+            source_format = self._source_format(source)
+            self._source_formats[source_name] = source_format
+            self.clients[source_name].configure_source(source_format)
+
+    def set_lang(self, lang: str):
+        """Update expected input language on both active sessions."""
+        languages = [self._language_code(lang)]
+        for client in self.clients.values():
+            client.set_languages(languages)
+
+    def transcribe_audio_queue(self, audio_queue: queue.Queue):
+        """Continuously route tagged raw audio and serialize callback results."""
+        self._start_enabled_clients()
+        while not self._stop_event.is_set():
+            self._drain_result_queue()
+            try:
+                who_spoke, data, _time_spoken = audio_queue.get(timeout=0.05)
+            except queue.Empty:
+                continue
+
+            if self.transcribe and self._source_enabled.get(who_spoke, False):
+                try:
+                    self.clients[who_spoke].append_audio(data)
+                except Exception as exception:
+                    self._queue_error(who_spoke, f"Could not process source audio: {exception}")
+            self._drain_result_queue()
+
+        self._drain_result_queue()
+
+    def set_source_enabled(self, source_name: str, enabled: bool):
+        """Start or stop one billable network session as its capture source changes."""
+        if source_name not in self.clients:
+            return
+        self._source_enabled[source_name] = bool(enabled)
+        if enabled and self.transcribe and not self._stop_event.is_set():
+            self.clients[source_name].start()
+        else:
+            self.clients[source_name].stop()
+
+    def set_transcription_enabled(self, enabled: bool):
+        """Pause or resume all selected sessions with the desktop transcription toggle."""
+        self.transcribe = bool(enabled)
+        if self.transcribe:
+            self._start_enabled_clients()
+        else:
+            for client in self.clients.values():
+                client.stop()
+
+    def stop(self):
+        """Close both independent sessions and unblock the consumer loop."""
+        self._stop_event.set()
+        for client in self.clients.values():
+            client.stop()
+
+    def get_transcript(self, length: int = 0):
+        """Return only confirmed conversation rows, excluding volatile partials."""
+        return self.conversation.get_conversation(
+            sources=[constants.PERSONA_YOU, constants.PERSONA_SPEAKER],
+            length=length,
+        )
+
+    def clear_transcript_data_loop(self, audio_queue: queue.Queue):
+        while not self._stop_event.is_set():
+            if self._stop_event.wait(self.clear_transcript_interval_seconds):
+                return
+            if self.clear_transcript_periodically:
+                self.clear_transcriber_context(audio_queue)
+
+    def clear_transcriber_context(self, audio_queue: queue.Queue):
+        """Clear confirmed, partial, queued, and server-side uncommitted state."""
+        self._partial_items.clear()
+        self._completed_items.clear()
+        self._drain_queue(self._result_queue)
+        with audio_queue.mutex:
+            audio_queue.queue.clear()
+        for client in self.clients.values():
+            client.clear_audio()
+        self.conversation.clear_conversation_data()
+
+    def _start_enabled_clients(self):
+        if not self.transcribe or self._stop_event.is_set():
+            return
+        for source_name, client in self.clients.items():
+            if self._source_enabled[source_name]:
+                client.start()
+
+    def _queue_partial(self, source_name: str, item_id: str, text: str):
+        self._put_result(("partial", source_name, item_id, text, datetime.datetime.utcnow()))
+
+    def _queue_completed(self, source_name: str, item_id: str, text: str):
+        self._put_result(("completed", source_name, item_id, text, datetime.datetime.utcnow()), final=True)
+
+    def _queue_error(self, source_name: str, message: str):
+        self._put_result(("error", source_name, "", str(message), datetime.datetime.utcnow()), final=True)
+
+    def _put_result(self, event: tuple, final: bool = False):
+        try:
+            self._result_queue.put_nowait(event)
+        except queue.Full:
+            if not final:
+                return
+            try:
+                self._result_queue.get_nowait()
+                self._result_queue.put_nowait(event)
+            except queue.Empty:
+                pass
+
+    def _drain_result_queue(self):
+        while True:
+            try:
+                event_type, source_name, item_id, text, event_time = self._result_queue.get_nowait()
+            except queue.Empty:
+                return
+            if event_type == "partial":
+                self._handle_partial(source_name, item_id, text)
+            elif event_type == "completed":
+                self._handle_completed(source_name, item_id, text, event_time)
+            else:
+                logger.error("OpenAI Realtime (%s): %s", source_name, text)
+
+    def _handle_partial(self, source_name: str, item_id: str, text: str):
+        key = (source_name, item_id)
+        if key in self._completed_items or not text.strip():
+            return
+        update_previous = key in self._partial_items
+        published = self.conversation.publish_partial(
+            persona=source_name,
+            text=text,
+            update_previous=update_previous,
+        )
+        if published:
+            self._partial_items[key] = text
+
+    def _handle_completed(self, source_name: str, item_id: str, text: str, event_time):
+        key = (source_name, item_id)
+        if key in self._completed_items or not text.strip():
+            return
+        self._completed_items.add(key)
+        replace_ui_partial = self._partial_items.pop(key, None) is not None
+        self.conversation.update_conversation(
+            persona=source_name,
+            text=text.strip(),
+            time_spoken=event_time,
+            replace_ui_partial=replace_ui_partial,
+        )
+        self.transcript_changed_event.set()
+
+    @staticmethod
+    def _drain_queue(target_queue: queue.Queue):
+        try:
+            while True:
+                target_queue.get_nowait()
+        except queue.Empty:
+            pass

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -30,6 +30,23 @@ Deepgram:
   # It is the default for this app's chunked/pre-recorded Deepgram path.
   model: 'nova-3'
 
+OpenAIRealtime:
+  # Streaming STT configuration; the API key is reused from OpenAI.api_key.
+  model: 'gpt-live-transcribe'
+  input_sample_rate: 24000
+  turn_detection: 'server_vad'
+  delay: 'low'
+  capture_chunk_duration_ms: 100
+  vad_threshold: 0.5
+  vad_prefix_padding_ms: 300
+  vad_silence_duration_ms: 500
+  reconnect_attempts: 3
+  reconnect_backoff_seconds: 2
+  # At the default 100 ms streaming cadence this buffers about 12 seconds.
+  # Overflow is reported rather than silently discarded.
+  max_buffered_chunks: 120
+  event_queue_size: 500
+
 Together:
   api_key: 'API_KEY'
   # Supported models are at https://docs.together.ai/docs/inference-models

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -45,7 +45,10 @@ OpenAIRealtime:
   # At the default 100 ms streaming cadence this buffers about 12 seconds.
   # Overflow is reported rather than silently discarded.
   max_buffered_chunks: 120
+  # Shared capture ingress; overflow replaces the oldest block to keep latency bounded.
+  max_raw_audio_chunks: 240
   event_queue_size: 500
+  deduplication_cache_size: 2048
 
 Together:
   api_key: 'API_KEY'

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -31,10 +31,13 @@ Deepgram:
   model: 'nova-3'
 
 OpenAIRealtime:
-  # Streaming STT configuration; the API key is reused from OpenAI.api_key.
+  # Streaming STT model; the API key is reused from OpenAI.api_key.
   model: 'gpt-live-transcribe'
   input_sample_rate: 24000
-  turn_detection: 'server_vad'
+  # gpt-live-transcribe does not currently support server VAD. Audio is
+  # committed in bounded windows so finalized transcript rows keep arriving.
+  turn_detection: null
+  manual_commit_interval_seconds: 3
   delay: 'low'
   capture_chunk_duration_ms: 100
   vad_threshold: 0.5

--- a/app/transcribe/parameters.yaml
+++ b/app/transcribe/parameters.yaml
@@ -34,8 +34,8 @@ OpenAIRealtime:
   # Streaming STT model; the API key is reused from OpenAI.api_key.
   model: 'gpt-live-transcribe'
   input_sample_rate: 24000
-  # gpt-live-transcribe does not currently support server VAD. Audio is
-  # committed in bounded windows so finalized transcript rows keep arriving.
+  # Manual turn detection commits audio in bounded windows so finalized
+  # transcript rows arrive predictably. Set to server_vad for silence-based turns.
   turn_detection: null
   manual_commit_interval_seconds: 3
   delay: 'low'

--- a/app/transcribe/providers/openai_realtime.py
+++ b/app/transcribe/providers/openai_realtime.py
@@ -11,6 +11,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from collections import deque
 
 from sdk.streaming_transcriber_models import (
     PCM16MonoResampler,
@@ -84,9 +85,12 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
         self._partial_by_item: dict[str, str] = {}
         self._item_started_at: dict[str, datetime.datetime] = {}
         self._audio_timeline: list[tuple[float, float, datetime.datetime]] = []
+        self._pending_manual_commit_times: deque[datetime.datetime] = deque()
+        self._manual_buffer_started_at = None
         self._sent_audio_ms = 0.0
         self._uncommitted_audio_ms = 0.0
         self._timeline_lock = threading.Lock()
+        self._commit_lock = threading.RLock()
         self._transcript_callback = None
         self._error_callback = None
 
@@ -166,16 +170,17 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
 
     def commit(self):
         """Commit the current input buffer for manual-turn configurations."""
-        self._send_event({"type": "input_audio_buffer.commit"})
-        self._uncommitted_audio_ms = 0.0
+        self._commit_input_audio()
 
     def clear_audio(self):
         """Clear queued and server-side uncommitted audio."""
         self._drain_queue(self._audio_queue)
         with self._converter_lock:
             self._converter.reset()
-        self._uncommitted_audio_ms = 0.0
         self._partial_by_item.clear()
+        with self._timeline_lock:
+            self._manual_buffer_started_at = None
+            self._uncommitted_audio_ms = 0.0
         if self._connected_event.is_set():
             try:
                 self._send_event({"type": "input_audio_buffer.clear"})
@@ -205,6 +210,8 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
             with self._timeline_lock:
                 self._item_started_at.clear()
                 self._audio_timeline.clear()
+                self._pending_manual_commit_times.clear()
+                self._manual_buffer_started_at = None
                 self._sent_audio_ms = 0.0
                 self._uncommitted_audio_ms = 0.0
 
@@ -250,6 +257,8 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
                     self.api_key,
                     self._session_config(),
                 )
+                if self._stop_event.is_set():
+                    return
                 websocket_app = self._websocket_app_factory(
                     url,
                     header=[f"Authorization: Bearer {ephemeral_key}"],
@@ -258,6 +267,9 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
                     on_error=self._on_error,
                     on_close=self._on_close,
                 )
+                if self._stop_event.is_set():
+                    websocket_app.close()
+                    return
                 self._websocket = websocket_app
                 websocket_app.run_forever()
             except Exception as exception:
@@ -284,14 +296,17 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
             if self._stop_event.is_set():
                 return
             try:
-                self._send_event(
-                    {
-                        "type": "input_audio_buffer.append",
-                        "audio": base64.b64encode(pending[0]).decode("ascii"),
-                    }
-                )
-                self._record_sent_audio(pending[0], pending[1])
-                self._commit_if_due(len(pending[0]))
+                # Keep an explicit commit from overtaking audio that has reached
+                # the socket but has not yet been added to the local timeline.
+                with self._commit_lock:
+                    self._send_event(
+                        {
+                            "type": "input_audio_buffer.append",
+                            "audio": base64.b64encode(pending[0]).decode("ascii"),
+                        }
+                    )
+                    self._record_sent_audio(pending[0], pending[1])
+                    self._commit_if_due()
                 pending = None
             except Exception as exception:
                 self._connected_event.clear()
@@ -308,6 +323,8 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
             with self._timeline_lock:
                 self._item_started_at.clear()
                 self._audio_timeline.clear()
+                self._pending_manual_commit_times.clear()
+                self._manual_buffer_started_at = None
                 self._sent_audio_ms = 0.0
                 self._uncommitted_audio_ms = 0.0
             websocket_app.send(json.dumps(self._session_update_event()))
@@ -324,6 +341,13 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
 
         event_type = event.get("type")
         if event_type == "session.updated":
+            session_type = (event.get("session") or {}).get("type")
+            if session_type != "transcription":
+                self._emit_error("OpenAI Realtime accepted an unexpected session type.")
+                websocket_app = self._websocket
+                if websocket_app is not None:
+                    websocket_app.close()
+                return
             self._connected_event.set()
             logger.info(
                 "OpenAI Realtime (%s): transcription session connected; "
@@ -337,6 +361,14 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
                 self._item_started_at[item_id] = self._capture_time_for_audio_offset(
                     float(event.get("audio_start_ms") or 0)
                 )
+        elif event_type == "input_audio_buffer.committed":
+            item_id = str(event.get("item_id") or "")
+            if item_id:
+                with self._timeline_lock:
+                    if self._pending_manual_commit_times:
+                        self._item_started_at[item_id] = (
+                            self._pending_manual_commit_times.popleft()
+                        )
         elif event_type == TRANSCRIPT_DELTA_EVENT:
             item_id = str(event.get("item_id") or "")
             if not item_id:
@@ -409,13 +441,23 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
             },
         }
 
-    def _commit_if_due(self, audio_bytes: int):
+    def _commit_if_due(self):
         if self.turn_detection == "server_vad":
             return
-        self._uncommitted_audio_ms += audio_bytes / 2 / self.input_sample_rate * 1000
-        if self._uncommitted_audio_ms >= self.manual_commit_interval_ms:
-            self._send_event({"type": "input_audio_buffer.commit"})
-            self._uncommitted_audio_ms = 0.0
+        with self._timeline_lock:
+            commit_due = self._uncommitted_audio_ms >= self.manual_commit_interval_ms
+        if commit_due:
+            self._commit_input_audio()
+
+    def _commit_input_audio(self):
+        """Commit buffered audio and retain its capture time until OpenAI assigns an item ID."""
+        with self._commit_lock:
+            with self._timeline_lock:
+                self._send_event({"type": "input_audio_buffer.commit"})
+                if self._manual_buffer_started_at is not None:
+                    self._pending_manual_commit_times.append(self._manual_buffer_started_at)
+                self._manual_buffer_started_at = None
+                self._uncommitted_audio_ms = 0.0
 
     def _send_event(self, event: dict):
         websocket_app = self._websocket
@@ -431,6 +473,10 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
             start_ms = self._sent_audio_ms
             self._sent_audio_ms += duration_ms
             self._audio_timeline.append((start_ms, self._sent_audio_ms, chunk_started_at))
+            if self.turn_detection != "server_vad":
+                if self._manual_buffer_started_at is None:
+                    self._manual_buffer_started_at = chunk_started_at
+                self._uncommitted_audio_ms += duration_ms
 
     def _capture_time_for_audio_offset(self, audio_offset_ms: float) -> datetime.datetime:
         with self._timeline_lock:

--- a/app/transcribe/providers/openai_realtime.py
+++ b/app/transcribe/providers/openai_realtime.py
@@ -1,0 +1,409 @@
+"""OpenAI Realtime WebSocket transport for streaming transcription."""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import json
+import queue
+import re
+import threading
+import time
+from urllib.parse import quote
+
+from sdk.streaming_transcriber_models import (
+    PCM16MonoResampler,
+    StreamingSTTModelInterface,
+    StreamingTranscriptEvent,
+    TranscriptEventKind,
+)
+
+OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime"
+TRANSCRIPT_DELTA_EVENT = "conversation.item.input_audio_transcription.delta"
+TRANSCRIPT_COMPLETED_EVENT = "conversation.item.input_audio_transcription.completed"
+
+
+class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
+    """One persistent OpenAI Realtime transcription session for one audio source."""
+
+    def __init__(
+        self,
+        source_name: str,
+        source_format: dict,
+        config: dict,
+        websocket_app_factory=None,
+        sleep_func=time.sleep,
+    ):
+        api_key = str(config.get("api_key") or "").strip()
+        if not api_key or api_key == "API_KEY":
+            raise ValueError("OpenAI Realtime transcription requires an OpenAI API key.")
+
+        self.source_name = source_name
+        self.api_key = api_key
+        self.model = config.get("model", "gpt-live-transcribe")
+        self.input_sample_rate = int(config.get("input_sample_rate", 24000))
+        self.turn_detection = config.get("turn_detection", "server_vad")
+        self.reconnect_attempts = max(0, int(config.get("reconnect_attempts", 3)))
+        self.reconnect_backoff_seconds = max(0.0, float(config.get("reconnect_backoff_seconds", 2)))
+        self.max_buffered_chunks = max(1, int(config.get("max_buffered_chunks", 120)))
+        self.transcription_delay = config.get("delay", "low")
+        self.languages = list(config.get("languages") or [])
+        self.prompt = str(config.get("prompt") or "").strip()
+        self.keywords = list(config.get("keywords") or [])
+        self.vad_threshold = float(config.get("vad_threshold", 0.5))
+        self.vad_prefix_padding_ms = int(config.get("vad_prefix_padding_ms", 300))
+        self.vad_silence_duration_ms = int(config.get("vad_silence_duration_ms", 500))
+
+        self._converter = PCM16MonoResampler(
+            sample_rate=int(source_format["sample_rate"]),
+            sample_width=int(source_format["sample_width"]),
+            channels=int(source_format["channels"]),
+            target_rate=self.input_sample_rate,
+        )
+        self._converter_lock = threading.Lock()
+        self._websocket_app_factory = websocket_app_factory or self._default_websocket_app_factory
+        self._sleep = sleep_func
+        self._audio_queue: queue.Queue = queue.Queue(maxsize=self.max_buffered_chunks)
+        self._stop_event = threading.Event()
+        self._connected_event = threading.Event()
+        self._lifecycle_lock = threading.Lock()
+        self._websocket = None
+        self._connection_thread = None
+        self._sender_thread = None
+        self._partial_by_item: dict[str, str] = {}
+        self._item_started_at: dict[str, datetime.datetime] = {}
+        self._audio_timeline: list[tuple[float, float, datetime.datetime]] = []
+        self._sent_audio_ms = 0.0
+        self._timeline_lock = threading.Lock()
+        self._transcript_callback = None
+        self._error_callback = None
+
+    @staticmethod
+    def _default_websocket_app_factory(*args, **kwargs):
+        import websocket  # pylint: disable=import-outside-toplevel
+        return websocket.WebSocketApp(*args, **kwargs)
+
+    def start(self):
+        """Start connection and sender workers once; safe to call repeatedly."""
+        with self._lifecycle_lock:
+            if self._connection_thread and self._connection_thread.is_alive():
+                return
+            if self._sender_thread and self._sender_thread.is_alive():
+                self._stop_event.set()
+                self._connected_event.set()
+                self._sender_thread.join(timeout=2)
+                if self._sender_thread.is_alive():
+                    self._emit_error("Realtime sender did not stop; a duplicate worker was not started.")
+                    return
+            self._stop_event.clear()
+            self._connected_event.clear()
+            self._connection_thread = threading.Thread(
+                target=self._connection_loop,
+                name=f"OpenAIRealtime-{self.source_name}",
+                daemon=True,
+            )
+            self._sender_thread = threading.Thread(
+                target=self._sender_loop,
+                name=f"OpenAIRealtimeSender-{self.source_name}",
+                daemon=True,
+            )
+            self._connection_thread.start()
+            self._sender_thread.start()
+
+    def append_audio(self, audio: bytes, captured_at=None):
+        """Normalize source audio and enqueue it without allowing unbounded growth."""
+        with self._converter_lock:
+            converted = self._converter.convert(audio)
+        if not converted:
+            return
+        try:
+            self._audio_queue.put_nowait((converted, captured_at))
+        except queue.Full:
+            self._emit_error(
+                "Realtime audio buffer is full; the connection is not keeping up and audio was not queued."
+            )
+
+    def commit(self):
+        """Commit the current input buffer for manual-turn configurations."""
+        self._send_event({"type": "input_audio_buffer.commit"})
+
+    def clear_audio(self):
+        """Clear queued and server-side uncommitted audio."""
+        self._drain_queue(self._audio_queue)
+        with self._converter_lock:
+            self._converter.reset()
+        self._partial_by_item.clear()
+        if self._connected_event.is_set():
+            try:
+                self._send_event({"type": "input_audio_buffer.clear"})
+            except Exception as exception:  # network state may change between the check and send
+                self._emit_error(exception)
+
+    def stop(self):
+        """Stop workers and close the socket without leaving non-daemon resources."""
+        with self._lifecycle_lock:
+            self._stop_event.set()
+            self._connected_event.set()
+            websocket_app = self._websocket
+            if websocket_app is not None:
+                try:
+                    websocket_app.close()
+                except Exception as exception:  # close is best effort
+                    self._emit_error(exception)
+            current = threading.current_thread()
+            for worker in (self._sender_thread, self._connection_thread):
+                if worker and worker is not current and worker.is_alive():
+                    worker.join(timeout=2)
+            self._connected_event.clear()
+            self._drain_queue(self._audio_queue)
+            with self._converter_lock:
+                self._converter.reset()
+            self._partial_by_item.clear()
+            with self._timeline_lock:
+                self._item_started_at.clear()
+                self._audio_timeline.clear()
+                self._sent_audio_ms = 0.0
+
+    def set_transcript_callback(self, callback):
+        self._transcript_callback = callback
+
+    def set_error_callback(self, callback):
+        self._error_callback = callback
+
+    def set_languages(self, languages: list[str]):
+        """Update expected languages for future and active transcription turns."""
+        self.languages = list(languages or [])
+        if self._connected_event.is_set():
+            self._send_event(self._session_update_event())
+
+    def configure_source(self, source_format: dict):
+        """Replace the incremental converter when the selected device format changes."""
+        with self._converter_lock:
+            self._converter = PCM16MonoResampler(
+                sample_rate=int(source_format["sample_rate"]),
+                sample_width=int(source_format["sample_width"]),
+                channels=int(source_format["channels"]),
+                target_rate=self.input_sample_rate,
+            )
+
+    @property
+    def connected(self) -> bool:
+        return self._connected_event.is_set() and not self._stop_event.is_set()
+
+    def _connection_loop(self):
+        url = f"{OPENAI_REALTIME_URL}?model={quote(self.model)}"
+        headers = [f"Authorization: Bearer {self.api_key}"]
+        total_attempts = self.reconnect_attempts + 1
+        for attempt in range(total_attempts):
+            if self._stop_event.is_set():
+                return
+            if attempt:
+                self._emit_error(f"Realtime connection retry {attempt}/{self.reconnect_attempts}.")
+                self._sleep(self.reconnect_backoff_seconds * attempt)
+                if self._stop_event.is_set():
+                    return
+            try:
+                websocket_app = self._websocket_app_factory(
+                    url,
+                    header=headers,
+                    on_open=self._on_open,
+                    on_message=self._on_message,
+                    on_error=self._on_error,
+                    on_close=self._on_close,
+                )
+                self._websocket = websocket_app
+                websocket_app.run_forever()
+            except Exception as exception:
+                self._emit_error(exception)
+            finally:
+                self._connected_event.clear()
+                self._websocket = None
+            if self._stop_event.is_set():
+                return
+        self._emit_error("Realtime connection stopped after the configured retry limit.")
+        self._stop_event.set()
+        self._connected_event.set()
+
+    def _sender_loop(self):
+        pending = None
+        while not self._stop_event.is_set():
+            if pending is None:
+                try:
+                    pending = self._audio_queue.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+            if not self._connected_event.wait(timeout=0.1):
+                continue
+            if self._stop_event.is_set():
+                return
+            try:
+                self._send_event(
+                    {
+                        "type": "input_audio_buffer.append",
+                        "audio": base64.b64encode(pending[0]).decode("ascii"),
+                    }
+                )
+                self._record_sent_audio(pending[0], pending[1])
+                pending = None
+            except Exception as exception:
+                self._connected_event.clear()
+                self._emit_error(f"Audio send failed; reconnecting ({exception.__class__.__name__}).")
+                websocket_app = self._websocket
+                if websocket_app is not None:
+                    try:
+                        websocket_app.close()
+                    except Exception:
+                        pass
+
+    def _on_open(self, websocket_app):
+        try:
+            with self._timeline_lock:
+                self._item_started_at.clear()
+                self._audio_timeline.clear()
+                self._sent_audio_ms = 0.0
+            websocket_app.send(json.dumps(self._session_update_event()))
+            self._connected_event.set()
+        except Exception as exception:
+            self._emit_error(exception)
+            websocket_app.close()
+
+    def _on_message(self, _websocket_app, message):
+        try:
+            event = json.loads(message)
+        except (TypeError, json.JSONDecodeError):
+            self._emit_error("Realtime server returned an invalid JSON event.")
+            return
+
+        event_type = event.get("type")
+        if event_type == "input_audio_buffer.speech_started":
+            item_id = str(event.get("item_id") or "")
+            if item_id:
+                self._item_started_at[item_id] = self._capture_time_for_audio_offset(
+                    float(event.get("audio_start_ms") or 0)
+                )
+        elif event_type == TRANSCRIPT_DELTA_EVENT:
+            item_id = str(event.get("item_id") or "")
+            if not item_id:
+                return
+            delta = str(event.get("delta") or "")
+            current = self._partial_by_item.get(item_id, "")
+            updated = self._merge_delta(current, delta)
+            self._partial_by_item[item_id] = updated
+            if updated and self._transcript_callback:
+                self._transcript_callback(StreamingTranscriptEvent(
+                    kind=TranscriptEventKind.PARTIAL,
+                    source=self.source_name,
+                    item_id=item_id,
+                    text=updated,
+                ))
+        elif event_type == TRANSCRIPT_COMPLETED_EVENT:
+            item_id = str(event.get("item_id") or "")
+            if not item_id:
+                return
+            final_text = str(event.get("transcript") or "").strip()
+            self._partial_by_item.pop(item_id, None)
+            if final_text and self._transcript_callback:
+                self._transcript_callback(StreamingTranscriptEvent(
+                    kind=TranscriptEventKind.COMPLETED,
+                    source=self.source_name,
+                    item_id=item_id,
+                    text=final_text,
+                    time_spoken=self._item_started_at.pop(item_id, None),
+                ))
+        elif event_type in ("error", "conversation.item.input_audio_transcription.failed"):
+            error = event.get("error") or {}
+            self._emit_error(error.get("message") or error.get("code") or "Realtime transcription failed.")
+
+    def _on_error(self, _websocket_app, error):
+        if not self._stop_event.is_set():
+            self._emit_error(error)
+
+    def _on_close(self, _websocket_app, _status_code, _message):
+        self._connected_event.clear()
+
+    def _session_update_event(self) -> dict:
+        transcription = {"model": self.model, "delay": self.transcription_delay}
+        if self.languages:
+            transcription["languages"] = self.languages
+        if self.prompt:
+            transcription["prompt"] = self.prompt
+        if self.keywords:
+            transcription["keywords"] = self.keywords
+
+        turn_detection = None
+        if self.turn_detection == "server_vad":
+            turn_detection = {
+                "type": "server_vad",
+                "threshold": self.vad_threshold,
+                "prefix_padding_ms": self.vad_prefix_padding_ms,
+                "silence_duration_ms": self.vad_silence_duration_ms,
+            }
+
+        return {
+            "type": "session.update",
+            "session": {
+                "type": "transcription",
+                "audio": {
+                    "input": {
+                        "format": {"type": "audio/pcm", "rate": self.input_sample_rate},
+                        "transcription": transcription,
+                        "turn_detection": turn_detection,
+                    }
+                },
+            },
+        }
+
+    def _send_event(self, event: dict):
+        websocket_app = self._websocket
+        if websocket_app is None:
+            raise ConnectionError("Realtime WebSocket is not connected.")
+        websocket_app.send(json.dumps(event))
+
+    def _record_sent_audio(self, audio: bytes, captured_at):
+        duration_ms = len(audio) / 2 / self.input_sample_rate * 1000
+        captured_at = captured_at or datetime.datetime.utcnow()
+        chunk_started_at = captured_at - datetime.timedelta(milliseconds=duration_ms)
+        with self._timeline_lock:
+            start_ms = self._sent_audio_ms
+            self._sent_audio_ms += duration_ms
+            self._audio_timeline.append((start_ms, self._sent_audio_ms, chunk_started_at))
+
+    def _capture_time_for_audio_offset(self, audio_offset_ms: float) -> datetime.datetime:
+        with self._timeline_lock:
+            for index in range(len(self._audio_timeline) - 1, -1, -1):
+                start_ms, end_ms, captured_at = self._audio_timeline[index]
+                if start_ms <= audio_offset_ms <= end_ms:
+                    if index:
+                        del self._audio_timeline[:index]
+                    return captured_at + datetime.timedelta(milliseconds=audio_offset_ms - start_ms)
+        return datetime.datetime.utcnow()
+
+    def _emit_error(self, error):
+        message = self._sanitize_error(error)
+        if self._error_callback:
+            self._error_callback(self.source_name, message)
+
+    @staticmethod
+    def _sanitize_error(error) -> str:
+        message = str(error or "Unknown Realtime transcription error.")
+        message = re.sub(r"Bearer\s+\S+", "Bearer [REDACTED]", message, flags=re.IGNORECASE)
+        message = re.sub(r"sk-[A-Za-z0-9_-]+", "[REDACTED]", message)
+        return message[:500]
+
+    @staticmethod
+    def _merge_delta(current: str, delta: str) -> str:
+        if not delta:
+            return current
+        if delta == current:
+            return current
+        if delta.startswith(current):
+            return delta
+        return current + delta
+
+    @staticmethod
+    def _drain_queue(target_queue: queue.Queue):
+        try:
+            while True:
+                target_queue.get_nowait()
+        except queue.Empty:
+            pass

--- a/app/transcribe/providers/openai_realtime.py
+++ b/app/transcribe/providers/openai_realtime.py
@@ -9,7 +9,8 @@ import queue
 import re
 import threading
 import time
-from urllib.parse import quote
+import urllib.error
+import urllib.request
 
 from sdk.streaming_transcriber_models import (
     PCM16MonoResampler,
@@ -17,10 +18,12 @@ from sdk.streaming_transcriber_models import (
     StreamingTranscriptEvent,
     TranscriptEventKind,
 )
+from tsutils import app_logging as al
 
 OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime"
 TRANSCRIPT_DELTA_EVENT = "conversation.item.input_audio_transcription.delta"
 TRANSCRIPT_COMPLETED_EVENT = "conversation.item.input_audio_transcription.completed"
+logger = al.get_module_logger(al.TRANSCRIBER_LOGGER)
 
 
 class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
@@ -32,6 +35,7 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
         source_format: dict,
         config: dict,
         websocket_app_factory=None,
+        client_secret_factory=None,
         sleep_func=time.sleep,
     ):
         api_key = str(config.get("api_key") or "").strip()
@@ -53,6 +57,10 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
         self.vad_threshold = float(config.get("vad_threshold", 0.5))
         self.vad_prefix_padding_ms = int(config.get("vad_prefix_padding_ms", 300))
         self.vad_silence_duration_ms = int(config.get("vad_silence_duration_ms", 500))
+        self.manual_commit_interval_ms = max(
+            100,
+            int(float(config.get("manual_commit_interval_seconds", 3)) * 1000),
+        )
 
         self._converter = PCM16MonoResampler(
             sample_rate=int(source_format["sample_rate"]),
@@ -62,6 +70,9 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
         )
         self._converter_lock = threading.Lock()
         self._websocket_app_factory = websocket_app_factory or self._default_websocket_app_factory
+        self._client_secret_factory = (
+            client_secret_factory or self._default_client_secret_factory
+        )
         self._sleep = sleep_func
         self._audio_queue: queue.Queue = queue.Queue(maxsize=self.max_buffered_chunks)
         self._stop_event = threading.Event()
@@ -74,6 +85,7 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
         self._item_started_at: dict[str, datetime.datetime] = {}
         self._audio_timeline: list[tuple[float, float, datetime.datetime]] = []
         self._sent_audio_ms = 0.0
+        self._uncommitted_audio_ms = 0.0
         self._timeline_lock = threading.Lock()
         self._transcript_callback = None
         self._error_callback = None
@@ -82,6 +94,35 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
     def _default_websocket_app_factory(*args, **kwargs):
         import websocket  # pylint: disable=import-outside-toplevel
         return websocket.WebSocketApp(*args, **kwargs)
+
+    @staticmethod
+    def _default_client_secret_factory(api_key: str, session: dict) -> str:
+        """Mint a short-lived credential bound to a transcription session."""
+        request = urllib.request.Request(
+            "https://api.openai.com/v1/realtime/client_secrets",
+            data=json.dumps({"session": session}).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=15) as response:
+                payload = json.loads(response.read())
+        except urllib.error.HTTPError as error:
+            try:
+                payload = json.loads(error.read())
+                message = (payload.get("error") or {}).get("message")
+            except (AttributeError, json.JSONDecodeError):
+                message = None
+            raise ConnectionError(message or f"Could not create transcription session ({error.code}).") from None
+
+        session_type = (payload.get("session") or {}).get("type")
+        secret = str(payload.get("value") or "").strip()
+        if session_type != "transcription" or not secret:
+            raise ConnectionError("OpenAI did not create a valid transcription session credential.")
+        return secret
 
     def start(self):
         """Start connection and sender workers once; safe to call repeatedly."""
@@ -126,12 +167,14 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
     def commit(self):
         """Commit the current input buffer for manual-turn configurations."""
         self._send_event({"type": "input_audio_buffer.commit"})
+        self._uncommitted_audio_ms = 0.0
 
     def clear_audio(self):
         """Clear queued and server-side uncommitted audio."""
         self._drain_queue(self._audio_queue)
         with self._converter_lock:
             self._converter.reset()
+        self._uncommitted_audio_ms = 0.0
         self._partial_by_item.clear()
         if self._connected_event.is_set():
             try:
@@ -163,6 +206,7 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
                 self._item_started_at.clear()
                 self._audio_timeline.clear()
                 self._sent_audio_ms = 0.0
+                self._uncommitted_audio_ms = 0.0
 
     def set_transcript_callback(self, callback):
         self._transcript_callback = callback
@@ -191,8 +235,7 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
         return self._connected_event.is_set() and not self._stop_event.is_set()
 
     def _connection_loop(self):
-        url = f"{OPENAI_REALTIME_URL}?model={quote(self.model)}"
-        headers = [f"Authorization: Bearer {self.api_key}"]
+        url = OPENAI_REALTIME_URL
         total_attempts = self.reconnect_attempts + 1
         for attempt in range(total_attempts):
             if self._stop_event.is_set():
@@ -203,9 +246,13 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
                 if self._stop_event.is_set():
                     return
             try:
+                ephemeral_key = self._client_secret_factory(
+                    self.api_key,
+                    self._session_config(),
+                )
                 websocket_app = self._websocket_app_factory(
                     url,
-                    header=headers,
+                    header=[f"Authorization: Bearer {ephemeral_key}"],
                     on_open=self._on_open,
                     on_message=self._on_message,
                     on_error=self._on_error,
@@ -244,6 +291,7 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
                     }
                 )
                 self._record_sent_audio(pending[0], pending[1])
+                self._commit_if_due(len(pending[0]))
                 pending = None
             except Exception as exception:
                 self._connected_event.clear()
@@ -261,8 +309,8 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
                 self._item_started_at.clear()
                 self._audio_timeline.clear()
                 self._sent_audio_ms = 0.0
+                self._uncommitted_audio_ms = 0.0
             websocket_app.send(json.dumps(self._session_update_event()))
-            self._connected_event.set()
         except Exception as exception:
             self._emit_error(exception)
             websocket_app.close()
@@ -275,7 +323,15 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
             return
 
         event_type = event.get("type")
-        if event_type == "input_audio_buffer.speech_started":
+        if event_type == "session.updated":
+            self._connected_event.set()
+            logger.info(
+                "OpenAI Realtime (%s): transcription session connected; "
+                "transcription model=%s",
+                self.source_name,
+                self.model,
+            )
+        elif event_type == "input_audio_buffer.speech_started":
             item_id = str(event.get("item_id") or "")
             if item_id:
                 self._item_started_at[item_id] = self._capture_time_for_audio_offset(
@@ -322,6 +378,9 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
         self._connected_event.clear()
 
     def _session_update_event(self) -> dict:
+        return {"type": "session.update", "session": self._session_config()}
+
+    def _session_config(self) -> dict:
         transcription = {"model": self.model, "delay": self.transcription_delay}
         if self.languages:
             transcription["languages"] = self.languages
@@ -340,18 +399,23 @@ class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
             }
 
         return {
-            "type": "session.update",
-            "session": {
-                "type": "transcription",
-                "audio": {
-                    "input": {
-                        "format": {"type": "audio/pcm", "rate": self.input_sample_rate},
-                        "transcription": transcription,
-                        "turn_detection": turn_detection,
-                    }
-                },
+            "type": "transcription",
+            "audio": {
+                "input": {
+                    "format": {"type": "audio/pcm", "rate": self.input_sample_rate},
+                    "transcription": transcription,
+                    "turn_detection": turn_detection,
+                }
             },
         }
+
+    def _commit_if_due(self, audio_bytes: int):
+        if self.turn_detection == "server_vad":
+            return
+        self._uncommitted_audio_ms += audio_bytes / 2 / self.input_sample_rate * 1000
+        if self._uncommitted_audio_ms >= self.manual_commit_interval_ms:
+            self._send_event({"type": "input_audio_buffer.commit"})
+            self._uncommitted_audio_ms = 0.0
 
     def _send_event(self, event: dict):
         websocket_app = self._websocket

--- a/app/transcribe/providers/stt.py
+++ b/app/transcribe/providers/stt.py
@@ -11,6 +11,7 @@ import custom_speech_recognition as sr
 from sdk import transcriber_models as tm
 
 from ..audio_transcriber import DeepgramTranscriber, WhisperCPPTranscriber, WhisperTranscriber
+from ..openai_realtime_transcriber import OpenAIRealtimeTranscriber
 
 from tsutils import language, utilities
 
@@ -141,6 +142,16 @@ def create_stt_model(name: str, config: dict, api: bool):
 
 def create_transcriber(name: str, config: dict, api: bool, runtime):
     """Create the application transcriber for the selected STT provider."""
+    if name.lower() == "openai-realtime":
+        transcriber = OpenAIRealtimeTranscriber(
+            runtime.user_audio_recorder.source,
+            runtime.speaker_audio_recorder.source,
+            convo=runtime.convo,
+            config=config,
+        )
+        runtime.set_transcriber(transcriber)
+        return transcriber
+
     model = create_stt_model(name=name, config=config, api=api)
     audio_chunk_preprocessor = WhisperCppAudioPreprocessor() if name.lower() == "whisper.cpp" else None
 

--- a/app/transcribe/requirements.txt
+++ b/app/transcribe/requirements.txt
@@ -5,6 +5,7 @@ Wave==0.0.2
 standard-aifc==3.13.0; python_version >= "3.13"
 audioop-lts==0.2.2; python_version >= "3.13"
 openai==1.66.3  # Latest release as of 2025-03-17
+websocket-client>=1.8,<2  # OpenAI Realtime WebSocket transport
 customtkinter==5.2.2
 tkinter-tooltip  # Needed to show tooltips for ctk components
 PyAudioWPatch==0.2.12.8

--- a/app/transcribe/tests/test_desktop_services.py
+++ b/app/transcribe/tests/test_desktop_services.py
@@ -79,14 +79,14 @@ class TestSettingsService(unittest.TestCase):
         self.assertEqual(interval, 7)
         self.assertEqual(fake_config.override_values, [{"General": {"llm_response_interval": 7}}])
 
-    def test_save_audio_language_updates_model_and_config(self):
+    def test_save_audio_language_updates_transcriber_and_config(self):
         fake_config = FakeConfig(data={"General": {}, "OpenAI": {}})
-        stt_model = MagicMock()
+        transcriber = MagicMock()
         service = SettingsService(config_factory=lambda: fake_config)
 
-        service.save_audio_language("french", stt_model)
+        service.save_audio_language("french", transcriber)
 
-        stt_model.set_lang.assert_called_once_with("french")
+        transcriber.set_language.assert_called_once_with("french")
         self.assertEqual(fake_config.override_values, [{"OpenAI": {"audio_lang": "french"}}])
 
     def test_save_response_language_updates_system_prompt(self):

--- a/app/transcribe/tests/test_openai_realtime_model.py
+++ b/app/transcribe/tests/test_openai_realtime_model.py
@@ -1,6 +1,7 @@
 """Unit tests for the persistent OpenAI Realtime streaming model."""
 
 import base64
+import datetime
 import json
 import math
 import os
@@ -9,7 +10,8 @@ import threading
 import time
 import unittest
 
-from sdk.streaming_transcriber_models import OpenAIRealtimeSTTModel, PCM16MonoResampler
+from app.transcribe.providers.openai_realtime import OpenAIRealtimeSTTModel
+from sdk.streaming_transcriber_models import PCM16MonoResampler, TranscriptEventKind
 
 
 class FakeWebSocketApp:
@@ -41,15 +43,16 @@ class FakeWebSocketApp:
 
 
 class FakeWebSocketFactory:
-    def __init__(self, close_first=False):
+    def __init__(self, close_first=False, close_always=False):
         self.close_first = close_first
+        self.close_always = close_always
         self.instances = []
 
     def __call__(self, *args, **kwargs):
         instance = FakeWebSocketApp(
             *args,
             **kwargs,
-            close_immediately=self.close_first and not self.instances,
+            close_immediately=self.close_always or (self.close_first and not self.instances),
         )
         self.instances.append(instance)
         return instance
@@ -89,8 +92,7 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
     def setUp(self):
         self.factory = FakeWebSocketFactory()
         self.errors = []
-        self.partials = []
-        self.completed = []
+        self.events = []
         self.model = OpenAIRealtimeSTTModel(
             source_name="You",
             source_format={"sample_rate": 16000, "sample_width": 2, "channels": 1},
@@ -106,8 +108,7 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
             sleep_func=lambda _seconds: None,
         )
         self.model.set_error_callback(lambda *args: self.errors.append(args))
-        self.model.set_partial_callback(lambda *args: self.partials.append(args))
-        self.model.set_completed_callback(lambda *args: self.completed.append(args))
+        self.model.set_transcript_callback(self.events.append)
 
     def tearDown(self):
         self.model.stop()
@@ -131,7 +132,7 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
         self.assertEqual(append_event["type"], "input_audio_buffer.append")
         self.assertGreater(len(base64.b64decode(append_event["audio"])), 320)
 
-    def test_deltas_are_replaced_by_one_authoritative_completion(self):
+    def test_deltas_and_completions_are_emitted_as_typed_events(self):
         self.model.start()
         self.assertTrue(wait_for(lambda: self.model.connected))
         socket = self.factory.instances[0]
@@ -153,8 +154,35 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
         socket.emit(completed)
         socket.emit(completed)
 
-        self.assertEqual(self.partials, [("You", "item-1", "Hello"), ("You", "item-1", "Hello world")])
-        self.assertEqual(self.completed, [("You", "item-1", "Hello world.")])
+        partials = [event for event in self.events if event.kind is TranscriptEventKind.PARTIAL]
+        completed_events = [event for event in self.events if event.kind is TranscriptEventKind.COMPLETED]
+        self.assertEqual([event.text for event in partials], ["Hello", "Hello world"])
+        self.assertEqual([event.text for event in completed_events], ["Hello world.", "Hello world."])
+
+    def test_completion_uses_capture_time_from_speech_start(self):
+        captured_at = datetime.datetime(2026, 1, 1, 12, 0, 1)
+        self.model.start()
+        self.assertTrue(wait_for(lambda: self.model.connected))
+        socket = self.factory.instances[0]
+        self.model.append_audio(b"\x01\x00" * 2400, captured_at=captured_at)
+        self.assertTrue(wait_for(lambda: len(socket.messages) >= 2))
+        socket.emit({
+            "type": "input_audio_buffer.speech_started",
+            "item_id": "item-timed",
+            "audio_start_ms": 25,
+        })
+        socket.emit({
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "item-timed",
+            "transcript": "Timed speech",
+        })
+
+        expected = captured_at - datetime.timedelta(milliseconds=125)
+        self.assertAlmostEqual(
+            self.events[-1].time_spoken.timestamp(),
+            expected.timestamp(),
+            places=3,
+        )
 
     def test_manual_commit_and_clean_disconnect(self):
         self.model.start()
@@ -163,6 +191,25 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
         self.assertEqual(self.factory.instances[0].messages[-1]["type"], "input_audio_buffer.commit")
         self.model.stop()
         self.assertFalse(self.model.connected)
+
+    def test_source_reconfiguration_is_safe_during_audio_append(self):
+        errors = []
+
+        def append_audio():
+            try:
+                for _ in range(100):
+                    self.model.append_audio(b"\x01\x00" * 160)
+            except Exception as exception:  # test captures any cross-thread failure
+                errors.append(exception)
+
+        worker = threading.Thread(target=append_audio)
+        worker.start()
+        for sample_rate in (24000, 16000, 48000, 16000):
+            self.model.configure_source({"sample_rate": sample_rate, "sample_width": 2, "channels": 1})
+        worker.join(timeout=2)
+
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(errors, [])
 
     def test_reconnects_independently_with_bounded_attempts(self):
         factory = FakeWebSocketFactory(close_first=True)
@@ -181,6 +228,32 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
             model.start()
             self.assertTrue(wait_for(lambda: len(factory.instances) == 2))
             self.assertTrue(wait_for(lambda: model.connected))
+        finally:
+            model.stop()
+
+    def test_restart_after_retry_exhaustion_replaces_sender_worker(self):
+        factory = FakeWebSocketFactory(close_always=True)
+        model = OpenAIRealtimeSTTModel(
+            source_name="Speaker",
+            source_format={"sample_rate": 48000, "sample_width": 2, "channels": 2},
+            config={"api_key": "test-key", "reconnect_attempts": 0},
+            websocket_app_factory=factory,
+            sleep_func=lambda _seconds: None,
+        )
+        try:
+            model.start()
+            first_sender = model._sender_thread
+            self.assertTrue(wait_for(lambda: not first_sender.is_alive()))
+
+            factory.close_always = False
+            model.start()
+            self.assertIsNot(model._sender_thread, first_sender)
+            self.assertTrue(wait_for(lambda: model.connected))
+            active_senders = [
+                thread for thread in threading.enumerate()
+                if thread.name == "OpenAIRealtimeSender-Speaker"
+            ]
+            self.assertEqual(len(active_senders), 1)
         finally:
             model.stop()
 

--- a/app/transcribe/tests/test_openai_realtime_model.py
+++ b/app/transcribe/tests/test_openai_realtime_model.py
@@ -15,7 +15,17 @@ from sdk.streaming_transcriber_models import PCM16MonoResampler, TranscriptEvent
 
 
 class FakeWebSocketApp:
-    def __init__(self, url, header, on_open, on_message, on_error, on_close, close_immediately=False):
+    def __init__(
+        self,
+        url,
+        header,
+        on_open,
+        on_message,
+        on_error,
+        on_close,
+        close_immediately=False,
+        acknowledge_session=True,
+    ):
         self.url = url
         self.header = header
         self.on_open = on_open
@@ -23,6 +33,7 @@ class FakeWebSocketApp:
         self.on_error = on_error
         self.on_close = on_close
         self.close_immediately = close_immediately
+        self.acknowledge_session = acknowledge_session
         self.messages = []
         self.closed = threading.Event()
 
@@ -31,6 +42,8 @@ class FakeWebSocketApp:
 
     def run_forever(self):
         self.on_open(self)
+        if self.acknowledge_session and not self.close_immediately:
+            self.emit({"type": "session.updated", "session": {"type": "transcription"}})
         if not self.close_immediately:
             self.closed.wait(2)
         self.on_close(self, 1000, "closed")
@@ -43,9 +56,10 @@ class FakeWebSocketApp:
 
 
 class FakeWebSocketFactory:
-    def __init__(self, close_first=False, close_always=False):
+    def __init__(self, close_first=False, close_always=False, acknowledge_session=True):
         self.close_first = close_first
         self.close_always = close_always
+        self.acknowledge_session = acknowledge_session
         self.instances = []
 
     def __call__(self, *args, **kwargs):
@@ -53,6 +67,7 @@ class FakeWebSocketFactory:
             *args,
             **kwargs,
             close_immediately=self.close_always or (self.close_first and not self.instances),
+            acknowledge_session=self.acknowledge_session,
         )
         self.instances.append(instance)
         return instance
@@ -93,6 +108,12 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
         self.factory = FakeWebSocketFactory()
         self.errors = []
         self.events = []
+        self.secret_requests = []
+
+        def create_secret(api_key, session):
+            self.secret_requests.append((api_key, session))
+            return "test-ephemeral-key"
+
         self.model = OpenAIRealtimeSTTModel(
             source_name="You",
             source_format={"sample_rate": 16000, "sample_width": 2, "channels": 1},
@@ -100,11 +121,13 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
                 "api_key": "test-key",
                 "model": "gpt-live-transcribe",
                 "languages": ["en"],
-                "turn_detection": "server_vad",
+                "turn_detection": None,
+                "manual_commit_interval_seconds": 3,
                 "reconnect_attempts": 1,
                 "reconnect_backoff_seconds": 0,
             },
             websocket_app_factory=self.factory,
+            client_secret_factory=create_secret,
             sleep_func=lambda _seconds: None,
         )
         self.model.set_error_callback(lambda *args: self.errors.append(args))
@@ -119,18 +142,49 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
         socket = self.factory.instances[0]
         session_event = socket.messages[0]
 
+        self.assertEqual(
+            socket.url,
+            "wss://api.openai.com/v1/realtime",
+        )
+        self.assertEqual(socket.header, ["Authorization: Bearer test-ephemeral-key"])
+        self.assertEqual(self.secret_requests[0][0], "test-key")
+        self.assertEqual(self.secret_requests[0][1]["type"], "transcription")
         self.assertEqual(session_event["session"]["type"], "transcription")
         input_config = session_event["session"]["audio"]["input"]
         self.assertEqual(input_config["format"], {"type": "audio/pcm", "rate": 24000})
         self.assertEqual(input_config["transcription"]["model"], "gpt-live-transcribe")
         self.assertEqual(input_config["transcription"]["languages"], ["en"])
-        self.assertEqual(input_config["turn_detection"]["type"], "server_vad")
+        self.assertIsNone(input_config["turn_detection"])
 
         self.model.append_audio(b"\x01\x00" * 160)
         self.assertTrue(wait_for(lambda: len(socket.messages) >= 2))
         append_event = socket.messages[1]
         self.assertEqual(append_event["type"], "input_audio_buffer.append")
         self.assertGreater(len(base64.b64decode(append_event["audio"])), 320)
+
+    def test_connection_is_ready_only_after_session_is_accepted(self):
+        factory = FakeWebSocketFactory(acknowledge_session=False)
+        model = OpenAIRealtimeSTTModel(
+            source_name="Speaker",
+            source_format={"sample_rate": 48000, "sample_width": 2, "channels": 2},
+            config={"api_key": "test-key", "reconnect_attempts": 0},
+            websocket_app_factory=factory,
+            client_secret_factory=lambda *_args: "test-ephemeral-key",
+            sleep_func=lambda _seconds: None,
+        )
+        try:
+            model.start()
+            self.assertTrue(wait_for(lambda: len(factory.instances) == 1))
+            self.assertTrue(wait_for(lambda: len(factory.instances[0].messages) == 1))
+            self.assertFalse(model.connected)
+
+            factory.instances[0].emit({
+                "type": "session.updated",
+                "session": {"type": "transcription"},
+            })
+            self.assertTrue(wait_for(lambda: model.connected))
+        finally:
+            model.stop()
 
     def test_deltas_and_completions_are_emitted_as_typed_events(self):
         self.model.start()
@@ -192,6 +246,17 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
         self.model.stop()
         self.assertFalse(self.model.connected)
 
+    def test_manual_turn_mode_commits_audio_periodically(self):
+        self.model.start()
+        self.assertTrue(wait_for(lambda: self.model.connected))
+        socket = self.factory.instances[0]
+
+        self.model.append_audio(b"\x01\x00" * 50000)
+        self.assertTrue(wait_for(lambda: len(socket.messages) >= 3))
+
+        self.assertEqual(socket.messages[-2]["type"], "input_audio_buffer.append")
+        self.assertEqual(socket.messages[-1]["type"], "input_audio_buffer.commit")
+
     def test_source_reconfiguration_is_safe_during_audio_append(self):
         errors = []
 
@@ -222,6 +287,7 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
                 "reconnect_backoff_seconds": 0,
             },
             websocket_app_factory=factory,
+            client_secret_factory=lambda *_args: "test-ephemeral-key",
             sleep_func=lambda _seconds: None,
         )
         try:
@@ -238,6 +304,7 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
             source_format={"sample_rate": 48000, "sample_width": 2, "channels": 2},
             config={"api_key": "test-key", "reconnect_attempts": 0},
             websocket_app_factory=factory,
+            client_secret_factory=lambda *_args: "test-ephemeral-key",
             sleep_func=lambda _seconds: None,
         )
         try:

--- a/app/transcribe/tests/test_openai_realtime_model.py
+++ b/app/transcribe/tests/test_openai_realtime_model.py
@@ -1,0 +1,224 @@
+"""Unit tests for the persistent OpenAI Realtime streaming model."""
+
+import base64
+import json
+import math
+import os
+import struct
+import threading
+import time
+import unittest
+
+from sdk.streaming_transcriber_models import OpenAIRealtimeSTTModel, PCM16MonoResampler
+
+
+class FakeWebSocketApp:
+    def __init__(self, url, header, on_open, on_message, on_error, on_close, close_immediately=False):
+        self.url = url
+        self.header = header
+        self.on_open = on_open
+        self.on_message = on_message
+        self.on_error = on_error
+        self.on_close = on_close
+        self.close_immediately = close_immediately
+        self.messages = []
+        self.closed = threading.Event()
+
+    def send(self, message):
+        self.messages.append(json.loads(message))
+
+    def run_forever(self):
+        self.on_open(self)
+        if not self.close_immediately:
+            self.closed.wait(2)
+        self.on_close(self, 1000, "closed")
+
+    def close(self):
+        self.closed.set()
+
+    def emit(self, event):
+        self.on_message(self, json.dumps(event))
+
+
+class FakeWebSocketFactory:
+    def __init__(self, close_first=False):
+        self.close_first = close_first
+        self.instances = []
+
+    def __call__(self, *args, **kwargs):
+        instance = FakeWebSocketApp(
+            *args,
+            **kwargs,
+            close_immediately=self.close_first and not self.instances,
+        )
+        self.instances.append(instance)
+        return instance
+
+
+def wait_for(predicate, timeout=2):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+class TestPCM16MonoResampler(unittest.TestCase):
+    def test_split_unaligned_chunks_match_single_conversion(self):
+        samples = [int(10000 * math.sin(index / 8)) for index in range(320)]
+        stereo = b"".join(struct.pack("<hh", sample, -sample) for sample in samples)
+        whole = PCM16MonoResampler(16000, 2, 2).convert(stereo)
+
+        split_converter = PCM16MonoResampler(16000, 2, 2)
+        split = b"".join(
+            split_converter.convert(chunk)
+            for chunk in (stereo[:7], stereo[7:101], stereo[101:])
+        )
+
+        self.assertEqual(split, whole)
+        self.assertEqual(len(split) % 2, 0)
+
+    def test_multichannel_input_is_downmixed(self):
+        frames = b"".join(struct.pack("<hhh", 3000, 0, -3000) for _ in range(10))
+        converted = PCM16MonoResampler(24000, 2, 3).convert(frames)
+        self.assertEqual(converted, b"\x00\x00" * 10)
+
+
+class TestOpenAIRealtimeSTTModel(unittest.TestCase):
+    def setUp(self):
+        self.factory = FakeWebSocketFactory()
+        self.errors = []
+        self.partials = []
+        self.completed = []
+        self.model = OpenAIRealtimeSTTModel(
+            source_name="You",
+            source_format={"sample_rate": 16000, "sample_width": 2, "channels": 1},
+            config={
+                "api_key": "test-key",
+                "model": "gpt-live-transcribe",
+                "languages": ["en"],
+                "turn_detection": "server_vad",
+                "reconnect_attempts": 1,
+                "reconnect_backoff_seconds": 0,
+            },
+            websocket_app_factory=self.factory,
+            sleep_func=lambda _seconds: None,
+        )
+        self.model.set_error_callback(lambda *args: self.errors.append(args))
+        self.model.set_partial_callback(lambda *args: self.partials.append(args))
+        self.model.set_completed_callback(lambda *args: self.completed.append(args))
+
+    def tearDown(self):
+        self.model.stop()
+
+    def test_opens_configures_and_sends_resampled_audio(self):
+        self.model.start()
+        self.assertTrue(wait_for(lambda: self.model.connected))
+        socket = self.factory.instances[0]
+        session_event = socket.messages[0]
+
+        self.assertEqual(session_event["session"]["type"], "transcription")
+        input_config = session_event["session"]["audio"]["input"]
+        self.assertEqual(input_config["format"], {"type": "audio/pcm", "rate": 24000})
+        self.assertEqual(input_config["transcription"]["model"], "gpt-live-transcribe")
+        self.assertEqual(input_config["transcription"]["languages"], ["en"])
+        self.assertEqual(input_config["turn_detection"]["type"], "server_vad")
+
+        self.model.append_audio(b"\x01\x00" * 160)
+        self.assertTrue(wait_for(lambda: len(socket.messages) >= 2))
+        append_event = socket.messages[1]
+        self.assertEqual(append_event["type"], "input_audio_buffer.append")
+        self.assertGreater(len(base64.b64decode(append_event["audio"])), 320)
+
+    def test_deltas_are_replaced_by_one_authoritative_completion(self):
+        self.model.start()
+        self.assertTrue(wait_for(lambda: self.model.connected))
+        socket = self.factory.instances[0]
+        socket.emit({
+            "type": "conversation.item.input_audio_transcription.delta",
+            "item_id": "item-1",
+            "delta": "Hello",
+        })
+        socket.emit({
+            "type": "conversation.item.input_audio_transcription.delta",
+            "item_id": "item-1",
+            "delta": " world",
+        })
+        completed = {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "item-1",
+            "transcript": "Hello world.",
+        }
+        socket.emit(completed)
+        socket.emit(completed)
+
+        self.assertEqual(self.partials, [("You", "item-1", "Hello"), ("You", "item-1", "Hello world")])
+        self.assertEqual(self.completed, [("You", "item-1", "Hello world.")])
+
+    def test_manual_commit_and_clean_disconnect(self):
+        self.model.start()
+        self.assertTrue(wait_for(lambda: self.model.connected))
+        self.model.commit()
+        self.assertEqual(self.factory.instances[0].messages[-1]["type"], "input_audio_buffer.commit")
+        self.model.stop()
+        self.assertFalse(self.model.connected)
+
+    def test_reconnects_independently_with_bounded_attempts(self):
+        factory = FakeWebSocketFactory(close_first=True)
+        model = OpenAIRealtimeSTTModel(
+            source_name="Speaker",
+            source_format={"sample_rate": 48000, "sample_width": 2, "channels": 2},
+            config={
+                "api_key": "test-key",
+                "reconnect_attempts": 1,
+                "reconnect_backoff_seconds": 0,
+            },
+            websocket_app_factory=factory,
+            sleep_func=lambda _seconds: None,
+        )
+        try:
+            model.start()
+            self.assertTrue(wait_for(lambda: len(factory.instances) == 2))
+            self.assertTrue(wait_for(lambda: model.connected))
+        finally:
+            model.stop()
+
+    def test_provider_errors_are_sanitized(self):
+        self.model.start()
+        self.assertTrue(wait_for(lambda: self.model.connected))
+        self.factory.instances[0].emit({
+            "type": "error",
+            "error": {"message": "Authorization: Bearer sk-secret-value quota exceeded"},
+        })
+        self.assertNotIn("sk-secret-value", self.errors[-1][1])
+
+    def test_missing_api_key_fails_before_starting_threads(self):
+        with self.assertRaisesRegex(ValueError, "requires an OpenAI API key"):
+            OpenAIRealtimeSTTModel(
+                source_name="You",
+                source_format={"sample_rate": 16000, "sample_width": 2, "channels": 1},
+                config={"api_key": "API_KEY"},
+            )
+
+
+@unittest.skipUnless(
+    os.environ.get("TRANSCRIBE_OPENAI_REALTIME_SMOKE") == "1" and os.environ.get("OPENAI_API_KEY"),
+    "Set TRANSCRIBE_OPENAI_REALTIME_SMOKE=1 and OPENAI_API_KEY for the live smoke test.",
+)
+class TestOpenAIRealtimeSmoke(unittest.TestCase):
+    def test_connect_and_close(self):
+        model = OpenAIRealtimeSTTModel(
+            source_name="Smoke",
+            source_format={"sample_rate": 24000, "sample_width": 2, "channels": 1},
+            config={"api_key": os.environ["OPENAI_API_KEY"], "reconnect_attempts": 0},
+        )
+        try:
+            model.start()
+            self.assertTrue(wait_for(lambda: model.connected, timeout=10))
+        finally:
+            model.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/transcribe/tests/test_openai_realtime_model.py
+++ b/app/transcribe/tests/test_openai_realtime_model.py
@@ -186,6 +186,32 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
         finally:
             model.stop()
 
+    def test_unexpected_session_type_is_rejected(self):
+        factory = FakeWebSocketFactory(acknowledge_session=False)
+        model = OpenAIRealtimeSTTModel(
+            source_name="Speaker",
+            source_format={"sample_rate": 48000, "sample_width": 2, "channels": 2},
+            config={"api_key": "test-key", "reconnect_attempts": 0},
+            websocket_app_factory=factory,
+            client_secret_factory=lambda *_args: "test-ephemeral-key",
+            sleep_func=lambda _seconds: None,
+        )
+        errors = []
+        model.set_error_callback(lambda *args: errors.append(args))
+        try:
+            model.start()
+            self.assertTrue(wait_for(lambda: len(factory.instances) == 1))
+            factory.instances[0].emit({
+                "type": "session.updated",
+                "session": {"type": "realtime"},
+            })
+
+            self.assertFalse(model.connected)
+            self.assertTrue(factory.instances[0].closed.is_set())
+            self.assertIn("unexpected session type", errors[-1][1])
+        finally:
+            model.stop()
+
     def test_deltas_and_completions_are_emitted_as_typed_events(self):
         self.model.start()
         self.assertTrue(wait_for(lambda: self.model.connected))
@@ -215,6 +241,7 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
 
     def test_completion_uses_capture_time_from_speech_start(self):
         captured_at = datetime.datetime(2026, 1, 1, 12, 0, 1)
+        self.model.turn_detection = "server_vad"
         self.model.start()
         self.assertTrue(wait_for(lambda: self.model.connected))
         socket = self.factory.instances[0]
@@ -238,6 +265,72 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
             places=3,
         )
 
+    def test_manual_commit_uses_capture_time_without_speech_started_event(self):
+        captured_at = datetime.datetime(2026, 1, 1, 12, 0, 5)
+        self.model.start()
+        self.assertTrue(wait_for(lambda: self.model.connected))
+        socket = self.factory.instances[0]
+        self.model.append_audio(b"\x01\x00" * 4800, captured_at=captured_at)
+        self.assertTrue(wait_for(lambda: len(socket.messages) >= 2))
+        self.model.commit()
+        socket.emit({
+            "type": "input_audio_buffer.committed",
+            "item_id": "item-manual",
+        })
+        socket.emit({
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "item-manual",
+            "transcript": "Manually committed speech",
+        })
+
+        expected = captured_at - datetime.timedelta(milliseconds=300)
+        self.assertAlmostEqual(
+            self.events[-1].time_spoken.timestamp(),
+            expected.timestamp(),
+            places=3,
+        )
+
+    def test_manual_commit_timestamps_follow_server_item_assignment_order(self):
+        first_captured_at = datetime.datetime(2026, 1, 1, 12, 0, 1)
+        second_captured_at = datetime.datetime(2026, 1, 1, 12, 0, 2)
+        self.model.start()
+        self.assertTrue(wait_for(lambda: self.model.connected))
+        socket = self.factory.instances[0]
+
+        for index, captured_at in enumerate((first_captured_at, second_captured_at), start=1):
+            self.model.append_audio(b"\x01\x00" * 2400, captured_at=captured_at)
+            self.assertTrue(wait_for(
+                lambda: sum(
+                    message["type"] == "input_audio_buffer.append"
+                    for message in socket.messages
+                ) >= index
+            ))
+            self.model.commit()
+
+        socket.emit({"type": "input_audio_buffer.committed", "item_id": "first"})
+        socket.emit({"type": "input_audio_buffer.committed", "item_id": "second"})
+        socket.emit({
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "second",
+            "transcript": "Second",
+        })
+        socket.emit({
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "first",
+            "transcript": "First",
+        })
+
+        expected = {
+            "first": first_captured_at - datetime.timedelta(milliseconds=150),
+            "second": second_captured_at - datetime.timedelta(milliseconds=150),
+        }
+        for event in self.events:
+            self.assertAlmostEqual(
+                event.time_spoken.timestamp(),
+                expected[event.item_id].timestamp(),
+                places=3,
+            )
+
     def test_manual_commit_and_clean_disconnect(self):
         self.model.start()
         self.assertTrue(wait_for(lambda: self.model.connected))
@@ -247,15 +340,28 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
         self.assertFalse(self.model.connected)
 
     def test_manual_turn_mode_commits_audio_periodically(self):
+        captured_at = datetime.datetime(2026, 1, 1, 12, 0, 5)
         self.model.start()
         self.assertTrue(wait_for(lambda: self.model.connected))
         socket = self.factory.instances[0]
 
-        self.model.append_audio(b"\x01\x00" * 50000)
+        self.model.append_audio(b"\x01\x00" * 50000, captured_at=captured_at)
         self.assertTrue(wait_for(lambda: len(socket.messages) >= 3))
 
         self.assertEqual(socket.messages[-2]["type"], "input_audio_buffer.append")
         self.assertEqual(socket.messages[-1]["type"], "input_audio_buffer.commit")
+        socket.emit({"type": "input_audio_buffer.committed", "item_id": "periodic"})
+        socket.emit({
+            "type": "conversation.item.input_audio_transcription.completed",
+            "item_id": "periodic",
+            "transcript": "Periodic commit",
+        })
+        expected = captured_at - datetime.timedelta(milliseconds=3125)
+        self.assertAlmostEqual(
+            self.events[-1].time_spoken.timestamp(),
+            expected.timestamp(),
+            places=3,
+        )
 
     def test_source_reconfiguration_is_safe_during_audio_append(self):
         errors = []
@@ -296,6 +402,35 @@ class TestOpenAIRealtimeSTTModel(unittest.TestCase):
             self.assertTrue(wait_for(lambda: model.connected))
         finally:
             model.stop()
+
+    def test_stop_during_secret_creation_does_not_open_websocket(self):
+        secret_requested = threading.Event()
+        release_secret = threading.Event()
+        factory = FakeWebSocketFactory()
+
+        def create_secret(*_args):
+            secret_requested.set()
+            release_secret.wait(2)
+            return "test-ephemeral-key"
+
+        model = OpenAIRealtimeSTTModel(
+            source_name="Speaker",
+            source_format={"sample_rate": 48000, "sample_width": 2, "channels": 2},
+            config={"api_key": "test-key", "reconnect_attempts": 0},
+            websocket_app_factory=factory,
+            client_secret_factory=create_secret,
+            sleep_func=lambda _seconds: None,
+        )
+        model.start()
+        self.assertTrue(secret_requested.wait(1))
+        stopper = threading.Thread(target=model.stop)
+        stopper.start()
+        self.assertTrue(wait_for(model._stop_event.is_set))
+        release_secret.set()
+        stopper.join(timeout=2)
+
+        self.assertFalse(stopper.is_alive())
+        self.assertEqual(factory.instances, [])
 
     def test_restart_after_retry_exhaustion_replaces_sender_worker(self):
         factory = FakeWebSocketFactory(close_always=True)

--- a/app/transcribe/tests/test_openai_realtime_transcriber.py
+++ b/app/transcribe/tests/test_openai_realtime_transcriber.py
@@ -1,11 +1,13 @@
 """Tests for source isolation and final-only persistence in the streaming adapter."""
 
+import datetime
 import queue
 import threading
 import time
 import unittest
 
 from app.transcribe.openai_realtime_transcriber import OpenAIRealtimeTranscriber
+from sdk.streaming_transcriber_models import StreamingTranscriptEvent, TranscriptEventKind
 
 
 class FakeSource:
@@ -25,16 +27,12 @@ class FakeClient:
         self.audio = []
         self.started = 0
         self.stopped = 0
-        self.partial_callback = None
-        self.completed_callback = None
+        self.transcript_callback = None
         self.error_callback = None
         self.__class__.instances[source_name] = self
 
-    def set_partial_callback(self, callback):
-        self.partial_callback = callback
-
-    def set_completed_callback(self, callback):
-        self.completed_callback = callback
+    def set_transcript_callback(self, callback):
+        self.transcript_callback = callback
 
     def set_error_callback(self, callback):
         self.error_callback = callback
@@ -45,8 +43,8 @@ class FakeClient:
     def stop(self):
         self.stopped += 1
 
-    def append_audio(self, audio):
-        self.audio.append(audio)
+    def append_audio(self, audio, captured_at=None):
+        self.audio.append((audio, captured_at))
 
     def clear_audio(self):
         self.audio.clear()
@@ -64,8 +62,8 @@ class FakeConversation:
         self.finals = []
         self.cleared = False
 
-    def publish_partial(self, persona, text, update_previous=False):
-        self.partials.append((persona, text, update_previous))
+    def publish_partial(self, persona, text, update_previous=False, partial_id=None):
+        self.partials.append((persona, text, update_previous, partial_id))
         return True
 
     def update_conversation(self, **kwargs):
@@ -87,6 +85,10 @@ def wait_for(predicate, timeout=2):
             return True
         time.sleep(0.01)
     return False
+
+
+def transcript_event(kind, source, item_id, text, time_spoken=None):
+    return StreamingTranscriptEvent(kind, source, item_id, text, time_spoken)
 
 
 class TestOpenAIRealtimeTranscriber(unittest.TestCase):
@@ -123,23 +125,24 @@ class TestOpenAIRealtimeTranscriber(unittest.TestCase):
     def test_microphone_and_speaker_use_independent_sessions(self):
         self.audio_queue.put(("You", b"mic", None))
         self.audio_queue.put(("Speaker", b"speaker", None))
-        self.assertTrue(wait_for(lambda: FakeClient.instances["You"].audio == [b"mic"]))
-        self.assertTrue(wait_for(lambda: FakeClient.instances["Speaker"].audio == [b"speaker"]))
+        self.assertTrue(wait_for(lambda: [item[0] for item in FakeClient.instances["You"].audio] == [b"mic"]))
+        self.assertTrue(wait_for(lambda: [item[0] for item in FakeClient.instances["Speaker"].audio] == [b"speaker"]))
 
         self.assertEqual(FakeClient.instances["You"].source_format["sample_rate"], 16000)
         self.assertEqual(FakeClient.instances["Speaker"].source_format["sample_rate"], 48000)
 
     def test_partial_is_replaced_and_only_final_is_persisted(self):
         client = FakeClient.instances["You"]
-        client.partial_callback("You", "item-1", "hel")
-        client.partial_callback("You", "item-1", "hello")
-        client.completed_callback("You", "item-1", "hello world")
-        client.completed_callback("You", "item-1", "hello world")
+        client.transcript_callback(transcript_event(TranscriptEventKind.PARTIAL, "You", "item-1", "hel"))
+        client.transcript_callback(transcript_event(TranscriptEventKind.PARTIAL, "You", "item-1", "hello"))
+        final = transcript_event(TranscriptEventKind.COMPLETED, "You", "item-1", "hello world")
+        client.transcript_callback(final)
+        client.transcript_callback(final)
 
         self.assertTrue(wait_for(lambda: len(self.conversation.finals) == 1))
         self.assertEqual(
             self.conversation.partials,
-            [("You", "hel", False), ("You", "hello", True)],
+            [("You", "hel", False, "You:item-1"), ("You", "hello", True, "You:item-1")],
         )
         self.assertEqual(self.conversation.finals[0]["text"], "hello world")
         self.assertTrue(self.conversation.finals[0]["replace_ui_partial"])
@@ -150,7 +153,7 @@ class TestOpenAIRealtimeTranscriber(unittest.TestCase):
         self.audio_queue.put(("You", b"mic", None))
         self.audio_queue.put(("Speaker", b"speaker", None))
 
-        self.assertTrue(wait_for(lambda: FakeClient.instances["You"].audio == [b"mic"]))
+        self.assertTrue(wait_for(lambda: [item[0] for item in FakeClient.instances["You"].audio] == [b"mic"]))
         time.sleep(0.05)
         self.assertEqual(FakeClient.instances["Speaker"].audio, [])
         self.assertGreaterEqual(FakeClient.instances["Speaker"].stopped, 1)
@@ -160,7 +163,7 @@ class TestOpenAIRealtimeTranscriber(unittest.TestCase):
         self.audio_queue.put(("You", b"mic", None))
         self.audio_queue.put(("Speaker", b"speaker", None))
 
-        self.assertTrue(wait_for(lambda: FakeClient.instances["Speaker"].audio == [b"speaker"]))
+        self.assertTrue(wait_for(lambda: [item[0] for item in FakeClient.instances["Speaker"].audio] == [b"speaker"]))
         time.sleep(0.05)
         self.assertEqual(FakeClient.instances["You"].audio, [])
         self.assertGreaterEqual(FakeClient.instances["You"].stopped, 1)
@@ -174,12 +177,76 @@ class TestOpenAIRealtimeTranscriber(unittest.TestCase):
         self.assertEqual(FakeClient.instances["Speaker"].started, 1)
 
     def test_clear_and_shutdown_cancel_all_resources(self):
-        FakeClient.instances["You"].completed_callback("You", "item-1", "final")
+        FakeClient.instances["You"].transcript_callback(
+            transcript_event(TranscriptEventKind.COMPLETED, "You", "item-1", "final")
+        )
         self.assertTrue(wait_for(lambda: len(self.conversation.finals) == 1))
         self.transcriber.clear_transcriber_context(self.audio_queue)
         self.assertTrue(self.conversation.cleared)
         self.transcriber.stop()
         self.assertTrue(all(client.stopped for client in FakeClient.instances.values()))
+
+    def test_completed_events_are_not_dropped_when_partial_queue_is_full(self):
+        self.transcriber._result_queue = queue.Queue(maxsize=1)
+        self.transcriber._result_queue.put(
+            transcript_event(TranscriptEventKind.PARTIAL, "You", "stale", "old")
+        )
+        client = FakeClient.instances["You"]
+
+        client.transcript_callback(transcript_event(
+            TranscriptEventKind.COMPLETED, "You", "item-1", "first", datetime.datetime(2026, 1, 1)
+        ))
+        client.transcript_callback(transcript_event(
+            TranscriptEventKind.COMPLETED, "You", "item-2", "second", datetime.datetime(2026, 1, 2)
+        ))
+
+        self.assertTrue(wait_for(lambda: len(self.conversation.finals) == 2))
+        self.assertEqual([item["text"] for item in self.conversation.finals], ["first", "second"])
+
+    def test_interleaved_items_keep_distinct_partial_ids(self):
+        client = FakeClient.instances["You"]
+        client.transcript_callback(transcript_event(TranscriptEventKind.PARTIAL, "You", "item-a", "alpha"))
+        client.transcript_callback(transcript_event(TranscriptEventKind.PARTIAL, "You", "item-b", "bravo"))
+        client.transcript_callback(
+            transcript_event(TranscriptEventKind.PARTIAL, "You", "item-a", "alpha updated")
+        )
+
+        self.assertTrue(wait_for(lambda: len(self.conversation.partials) == 3))
+        self.assertEqual(
+            [item[3] for item in self.conversation.partials],
+            ["You:item-a", "You:item-b", "You:item-a"],
+        )
+
+    def test_reverse_completions_preserve_capture_chronology(self):
+        speaker_time = datetime.datetime(2026, 1, 1, 12, 0, 0)
+        microphone_time = datetime.datetime(2026, 1, 1, 12, 0, 1)
+
+        FakeClient.instances["You"].transcript_callback(transcript_event(
+            TranscriptEventKind.COMPLETED, "You", "item-you", "second turn", microphone_time
+        ))
+        FakeClient.instances["Speaker"].transcript_callback(transcript_event(
+            TranscriptEventKind.COMPLETED, "Speaker", "item-speaker", "first turn", speaker_time
+        ))
+
+        self.assertTrue(wait_for(lambda: len(self.conversation.finals) == 2))
+        timestamps = {item["persona"]: item["time_spoken"] for item in self.conversation.finals}
+        self.assertEqual(timestamps, {"You": microphone_time, "Speaker": speaker_time})
+
+    def test_completed_item_cache_is_bounded(self):
+        self.transcriber._deduplication_cache_size = 2
+        for index in range(3):
+            self.transcriber._handle_completed(
+                transcript_event(
+                    TranscriptEventKind.COMPLETED,
+                    "You",
+                    f"item-{index}",
+                    f"turn {index}",
+                    datetime.datetime(2026, 1, 1, 12, 0, index),
+                )
+            )
+
+        self.assertEqual(len(self.transcriber._completed_items), 2)
+        self.assertNotIn(("You", "item-0"), self.transcriber._completed_items)
 
 
 if __name__ == "__main__":

--- a/app/transcribe/tests/test_openai_realtime_transcriber.py
+++ b/app/transcribe/tests/test_openai_realtime_transcriber.py
@@ -1,0 +1,186 @@
+"""Tests for source isolation and final-only persistence in the streaming adapter."""
+
+import queue
+import threading
+import time
+import unittest
+
+from app.transcribe.openai_realtime_transcriber import OpenAIRealtimeTranscriber
+
+
+class FakeSource:
+    def __init__(self, sample_rate, sample_width, channels):
+        self.SAMPLE_RATE = sample_rate
+        self.SAMPLE_WIDTH = sample_width
+        self.channels = channels
+
+
+class FakeClient:
+    instances = {}
+
+    def __init__(self, source_name, source_format, config):
+        self.source_name = source_name
+        self.source_format = source_format
+        self.config = config
+        self.audio = []
+        self.started = 0
+        self.stopped = 0
+        self.partial_callback = None
+        self.completed_callback = None
+        self.error_callback = None
+        self.__class__.instances[source_name] = self
+
+    def set_partial_callback(self, callback):
+        self.partial_callback = callback
+
+    def set_completed_callback(self, callback):
+        self.completed_callback = callback
+
+    def set_error_callback(self, callback):
+        self.error_callback = callback
+
+    def start(self):
+        self.started += 1
+
+    def stop(self):
+        self.stopped += 1
+
+    def append_audio(self, audio):
+        self.audio.append(audio)
+
+    def clear_audio(self):
+        self.audio.clear()
+
+    def configure_source(self, source_format):
+        self.source_format = source_format
+
+    def set_languages(self, languages):
+        self.config["languages"] = languages
+
+
+class FakeConversation:
+    def __init__(self):
+        self.partials = []
+        self.finals = []
+        self.cleared = False
+
+    def publish_partial(self, persona, text, update_previous=False):
+        self.partials.append((persona, text, update_previous))
+        return True
+
+    def update_conversation(self, **kwargs):
+        self.finals.append(kwargs)
+
+    def get_conversation(self, sources, length=0):
+        del sources, length
+        return "".join(f"{item['persona']}: [{item['text']}]\n\n" for item in self.finals)
+
+    def clear_conversation_data(self):
+        self.cleared = True
+        self.finals.clear()
+
+
+def wait_for(predicate, timeout=2):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+class TestOpenAIRealtimeTranscriber(unittest.TestCase):
+    def setUp(self):
+        FakeClient.instances = {}
+        self.conversation = FakeConversation()
+        self.audio_queue = queue.Queue()
+        self.transcriber = OpenAIRealtimeTranscriber(
+            FakeSource(16000, 2, 1),
+            FakeSource(48000, 2, 2),
+            convo=self.conversation,
+            config={
+                "OpenAI": {"api_key": "test-key", "audio_lang": "English"},
+                "OpenAIRealtime": {},
+                "General": {
+                    "clear_transcript_periodically": False,
+                    "clear_transcript_interval_seconds": 90,
+                },
+            },
+            client_factory=FakeClient,
+        )
+        self.thread = threading.Thread(
+            target=self.transcriber.transcribe_audio_queue,
+            args=(self.audio_queue,),
+            daemon=True,
+        )
+        self.thread.start()
+        self.assertTrue(wait_for(lambda: all(client.started for client in FakeClient.instances.values())))
+
+    def tearDown(self):
+        self.transcriber.stop()
+        self.thread.join(timeout=1)
+
+    def test_microphone_and_speaker_use_independent_sessions(self):
+        self.audio_queue.put(("You", b"mic", None))
+        self.audio_queue.put(("Speaker", b"speaker", None))
+        self.assertTrue(wait_for(lambda: FakeClient.instances["You"].audio == [b"mic"]))
+        self.assertTrue(wait_for(lambda: FakeClient.instances["Speaker"].audio == [b"speaker"]))
+
+        self.assertEqual(FakeClient.instances["You"].source_format["sample_rate"], 16000)
+        self.assertEqual(FakeClient.instances["Speaker"].source_format["sample_rate"], 48000)
+
+    def test_partial_is_replaced_and_only_final_is_persisted(self):
+        client = FakeClient.instances["You"]
+        client.partial_callback("You", "item-1", "hel")
+        client.partial_callback("You", "item-1", "hello")
+        client.completed_callback("You", "item-1", "hello world")
+        client.completed_callback("You", "item-1", "hello world")
+
+        self.assertTrue(wait_for(lambda: len(self.conversation.finals) == 1))
+        self.assertEqual(
+            self.conversation.partials,
+            [("You", "hel", False), ("You", "hello", True)],
+        )
+        self.assertEqual(self.conversation.finals[0]["text"], "hello world")
+        self.assertTrue(self.conversation.finals[0]["replace_ui_partial"])
+        self.assertEqual(self.transcriber.get_transcript(), "You: [hello world]\n\n")
+
+    def test_source_toggle_stops_only_that_session(self):
+        self.transcriber.set_source_enabled("Speaker", False)
+        self.audio_queue.put(("You", b"mic", None))
+        self.audio_queue.put(("Speaker", b"speaker", None))
+
+        self.assertTrue(wait_for(lambda: FakeClient.instances["You"].audio == [b"mic"]))
+        time.sleep(0.05)
+        self.assertEqual(FakeClient.instances["Speaker"].audio, [])
+        self.assertGreaterEqual(FakeClient.instances["Speaker"].stopped, 1)
+
+    def test_microphone_toggle_routes_only_speaker(self):
+        self.transcriber.set_source_enabled("You", False)
+        self.audio_queue.put(("You", b"mic", None))
+        self.audio_queue.put(("Speaker", b"speaker", None))
+
+        self.assertTrue(wait_for(lambda: FakeClient.instances["Speaker"].audio == [b"speaker"]))
+        time.sleep(0.05)
+        self.assertEqual(FakeClient.instances["You"].audio, [])
+        self.assertGreaterEqual(FakeClient.instances["You"].stopped, 1)
+
+    def test_pause_stops_both_sessions_and_resume_restarts_selected_sources(self):
+        self.transcriber.set_transcription_enabled(False)
+        self.assertTrue(all(client.stopped for client in FakeClient.instances.values()))
+        self.transcriber.set_source_enabled("Speaker", False)
+        self.transcriber.set_transcription_enabled(True)
+        self.assertGreaterEqual(FakeClient.instances["You"].started, 2)
+        self.assertEqual(FakeClient.instances["Speaker"].started, 1)
+
+    def test_clear_and_shutdown_cancel_all_resources(self):
+        FakeClient.instances["You"].completed_callback("You", "item-1", "final")
+        self.assertTrue(wait_for(lambda: len(self.conversation.finals) == 1))
+        self.transcriber.clear_transcriber_context(self.audio_queue)
+        self.assertTrue(self.conversation.cleared)
+        self.transcriber.stop()
+        self.assertTrue(all(client.stopped for client in FakeClient.instances.values()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/transcribe/tests/test_provider_stt.py
+++ b/app/transcribe/tests/test_provider_stt.py
@@ -8,6 +8,34 @@ from app.transcribe.providers import stt
 
 
 class TestSTTProviders(unittest.TestCase):
+    @patch("app.transcribe.providers.stt.OpenAIRealtimeTranscriber")
+    def test_create_openai_realtime_transcriber_bypasses_file_model_factory(self, mock_transcriber):
+        runtime = SimpleNamespace(
+            user_audio_recorder=SimpleNamespace(source="mic"),
+            speaker_audio_recorder=SimpleNamespace(source="speaker"),
+            convo="conversation",
+            set_transcriber=MagicMock(),
+        )
+        transcriber_instance = MagicMock()
+        mock_transcriber.return_value = transcriber_instance
+        config = {"General": {}, "OpenAI": {}, "OpenAIRealtime": {}}
+
+        created = stt.create_transcriber(
+            name="openai-realtime",
+            config=config,
+            api=False,
+            runtime=runtime,
+        )
+
+        self.assertIs(created, transcriber_instance)
+        mock_transcriber.assert_called_once_with(
+            "mic",
+            "speaker",
+            convo="conversation",
+            config=config,
+        )
+        runtime.set_transcriber.assert_called_once_with(transcriber_instance)
+
     @patch("app.transcribe.providers.stt.tm.STTModelFactory")
     def test_create_deepgram_model_uses_configured_nova3_model(self, mock_factory_class):
         factory = mock_factory_class.return_value

--- a/app/transcribe/tests/test_streaming_audio_capture.py
+++ b/app/transcribe/tests/test_streaming_audio_capture.py
@@ -84,6 +84,17 @@ class TestStreamingAudioCapture(unittest.TestCase):
 
         self.assertTrue(audio_queue.empty())
 
+    def test_full_ingress_queue_replaces_oldest_audio(self):
+        recorder = self.recorder([])
+        audio_queue = queue.Queue(maxsize=2)
+
+        recorder._enqueue_audio(audio_queue, b"first")
+        recorder._enqueue_audio(audio_queue, b"second")
+        recorder._enqueue_audio(audio_queue, b"latest")
+
+        self.assertEqual(audio_queue.qsize(), 2)
+        self.assertEqual([audio_queue.get()[1], audio_queue.get()[1]], [b"second", b"latest"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/app/transcribe/tests/test_streaming_audio_capture.py
+++ b/app/transcribe/tests/test_streaming_audio_capture.py
@@ -1,0 +1,89 @@
+"""Tests for the small-block capture path used by persistent STT providers."""
+
+import queue
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from sdk.audio_recorder import BaseRecorder
+
+
+class DummyRecorder(BaseRecorder):
+    def get_name(self):
+        return "dummy"
+
+
+class FakeStream:
+    def __init__(self, chunks):
+        self.chunks = list(chunks)
+        self.lock = threading.Lock()
+
+    def read(self, _size):
+        with self.lock:
+            return self.chunks.pop(0) if self.chunks else b""
+
+
+class FakeSource:
+    CHUNK = 4
+    SAMPLE_RATE = 1000
+
+    def __init__(self, chunks):
+        self.stream = FakeStream(chunks)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc_value, _traceback):
+        return False
+
+
+class TestStreamingAudioCapture(unittest.TestCase):
+    @staticmethod
+    def recorder(chunks):
+        recorder = DummyRecorder.__new__(DummyRecorder)
+        recorder.source = FakeSource(chunks)
+        recorder.source_name = "You"
+        recorder.enabled = True
+        recorder.audio_file_name = None
+        recorder.config = {"General": {"stt": "openai-realtime"}}
+        recorder.config["OpenAIRealtime"] = {"capture_chunk_duration_ms": 100}
+        return recorder
+
+    def test_continuous_capture_enqueues_raw_pcm_blocks(self):
+        recorder = self.recorder([b"first", b"second", b""])
+        audio_queue = queue.Queue()
+
+        stop = recorder._record_audio_continuously(audio_queue)
+        deadline = time.time() + 1
+        while audio_queue.qsize() < 2 and time.time() < deadline:
+            time.sleep(0.01)
+        stop(wait_for_stop=True)
+
+        captured = [audio_queue.get_nowait(), audio_queue.get_nowait()]
+        self.assertEqual([item[0] for item in captured], ["You", "You"])
+        self.assertEqual([item[1] for item in captured], [b"first", b"second"])
+
+    def test_record_audio_selects_streaming_path_only_for_realtime_backend(self):
+        recorder = self.recorder([])
+        recorder._record_audio_continuously = MagicMock(return_value="stop")
+        audio_queue = queue.Queue()
+
+        result = recorder.record_audio(audio_queue)
+
+        self.assertEqual(result, "stop")
+        recorder._record_audio_continuously.assert_called_once_with(audio_queue)
+
+    def test_disabled_source_does_not_enqueue_audio(self):
+        recorder = self.recorder([b"ignored", b""])
+        recorder.enabled = False
+        audio_queue = queue.Queue()
+
+        stop = recorder._record_audio_continuously(audio_queue)
+        stop(wait_for_stop=True)
+
+        self.assertTrue(audio_queue.empty())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/transcribe/transcriber.py
+++ b/app/transcribe/transcriber.py
@@ -1,0 +1,31 @@
+"""Runtime contract shared by file/window and persistent streaming transcribers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class TranscriberInterface(ABC):
+    """Common lifecycle and control surface used by the desktop application."""
+
+    transcribe: bool
+
+    @abstractmethod
+    def set_source_properties(self, mic_source=None, speaker_source=None):
+        """Update capture formats after device selection."""
+
+    @abstractmethod
+    def set_source_enabled(self, source_name: str, enabled: bool):
+        """Apply source enablement to provider resources when required."""
+
+    @abstractmethod
+    def set_transcription_enabled(self, enabled: bool):
+        """Pause or resume transcription resources."""
+
+    @abstractmethod
+    def set_language(self, lang: str):
+        """Update the expected source-audio language."""
+
+    @abstractmethod
+    def stop(self):
+        """Release provider resources."""

--- a/app/transcribe/uicomp/selectable_text.py
+++ b/app/transcribe/uicomp/selectable_text.py
@@ -196,6 +196,39 @@ class SelectableText(ctk.CTkFrame):
         self.text_widget.insert(END, input_text + "\n")
         self.text_widget.configure(state="disabled")
 
+    @staticmethod
+    def _row_tag(row_key: str) -> str:
+        return f"transcript-row-{row_key}"
+
+    def upsert_keyed_row(self, row_key: str, input_text: str):
+        """Insert or replace a transcript row without depending on its position."""
+        tag = self._row_tag(row_key)
+        self.text_widget.configure(state="normal")
+        ranges = self.text_widget.tag_ranges(tag)
+        if ranges:
+            start, end = ranges[0], ranges[1]
+            self.text_widget.delete(start, end)
+            self.text_widget.insert(start, input_text + "\n", tag)
+        else:
+            start = self.text_widget.index(END)
+            self.text_widget.insert(END, input_text + "\n", tag)
+        self.text_widget.configure(state="disabled")
+        self.scroll_to_bottom()
+
+    def finalize_keyed_row(self, row_key: str, input_text: str):
+        """Replace a transient row with final text and remove its provider tag."""
+        tag = self._row_tag(row_key)
+        self.text_widget.configure(state="normal")
+        ranges = self.text_widget.tag_ranges(tag)
+        if ranges:
+            start, end = ranges[0], ranges[1]
+            self.text_widget.delete(start, end)
+            self.text_widget.insert(start, input_text + "\n")
+        else:
+            self.text_widget.insert(END, input_text + "\n")
+        self.text_widget.configure(state="disabled")
+        self.scroll_to_bottom()
+
     def delete_row_starting_with(self, start_text: str):
         """Delete the row that starts with the given text."""
         self.text_widget.configure(state="normal")

--- a/docs/AppConfig.md
+++ b/docs/AppConfig.md
@@ -31,5 +31,16 @@ General:
 
 Details of specific elements are available in `parameters.yaml` file itself.
 
+Realtime transcription has its own `OpenAIRealtime` section so response-LLM settings and streaming STT settings remain independent. It reuses only `OpenAI.api_key`:
+
+```yaml
+OpenAIRealtime:
+  model: 'gpt-live-transcribe'
+  delay: 'low'
+  reconnect_attempts: 3
+```
+
+See [OpenAI Realtime transcription](./OpenAIRealtime.md) for all supported values and operational behavior.
+
 ## Revert to Default Config
 Remove all contents of `override.yaml` file to rever the applicationn to Default config.

--- a/docs/ModelSelection.md
+++ b/docs/ModelSelection.md
@@ -5,7 +5,7 @@ Transcribe architecture has two primary components that require model selection
 - LLM Responses
 
 ## Speech to Text
-Speech to text aspect can be done locally or online using the Whisper API. Online Speech to Text requires use of `-api` option on command line.
+Speech to text can run locally, through a recorded-window API, or through a persistent streaming API.
 
 ### Local Speech to Text
 Local Speech to Text requires model selection. By default the `base` model for English is used. This model is downloaded on the first invocation of the application. There are many more models available, though they vary by size and compute power required.
@@ -34,7 +34,19 @@ See the help of transcribe `python main.py -h` for further details on local tran
 ```
 
 ### Online Speech to Text
-Online Speech to Text option is enabled using `--api` option. This option does not require model selection as the appropriate model is selected by the API behind the scenes.
+The existing Whisper file API is enabled with `--api` while the `whisper` engine is selected:
+
+```powershell
+python main.py -stt whisper --api
+```
+
+OpenAI Realtime is a separate streaming backend and does not use `--api`:
+
+```powershell
+python main.py -stt openai-realtime
+```
+
+It uses `gpt-live-transcribe`, persistent WebSockets, and independent microphone and speaker-loopback sessions. See [OpenAI Realtime transcription](./OpenAIRealtime.md). Deepgram remains a recorded-window provider in the current application architecture.
 
 ## LLM Responses
 The quality, cost and speed of responses from LLM depends on the model chosen. Out of the box transcribe uses `gpt-3.5-turbo-0301` model as specified in parameters.yaml

--- a/docs/OpenAIRealtime.md
+++ b/docs/OpenAIRealtime.md
@@ -65,6 +65,10 @@ OpenAIRealtime:
   capture_chunk_duration_ms: 100
   reconnect_attempts: 3
   reconnect_backoff_seconds: 2
+  max_buffered_chunks: 120
+  max_raw_audio_chunks: 240
+  event_queue_size: 500
+  deduplication_cache_size: 2048
 ```
 
 Supported delay presets are `minimal`, `low`, `medium`, `high`, and `xhigh`. Lower delay produces earlier partials; higher delay gives the model more context. The OpenAI API may reject unsupported language codes or invalid keyword hints.
@@ -72,7 +76,9 @@ Supported delay presets are `minimal`, `low`, `medium`, `high`, and `xhigh`. Low
 ## Reliability, cost, and privacy
 
 - Microphone and speaker sessions reconnect independently with a bounded backoff.
-- Audio waiting for a temporarily disconnected socket is bounded. Buffer overflow is reported as an error rather than hidden.
+- Audio waiting for a temporarily disconnected socket is bounded. Per-session overflow is reported as an error.
+- The shared capture ingress is also bounded; if it fills, the oldest block is replaced so latency and memory remain bounded.
+- Provider item IDs are retained in a bounded cache to suppress duplicate completions without growing for the application lifetime.
 - Two enabled sources mean two independently processed live streams and corresponding API usage.
 - Audio is sent to OpenAI for transcription. Review OpenAI's current data controls and your organization's privacy requirements.
 - The application's existing shutdown flow may also save microphone and speaker WAV recordings in its local application-data directory; Realtime mode does not add audio to logs.

--- a/docs/OpenAIRealtime.md
+++ b/docs/OpenAIRealtime.md
@@ -1,0 +1,92 @@
+# OpenAI Realtime Transcription
+
+Transcribe can use OpenAI's `gpt-live-transcribe` model as an optional native streaming speech-to-text backend. This is different from the existing Whisper API mode: Whisper API repeatedly uploads recorded WAV windows, while OpenAI Realtime keeps a WebSocket session open and returns transcript deltas as audio arrives.
+
+## Setup
+
+Install the normal source dependencies with `setup.bat`, then place an OpenAI API key in `app/transcribe/override.yaml`:
+
+```yaml
+OpenAI:
+  api_key: 'YOUR_OPENAI_API_KEY'
+```
+
+Do not commit `override.yaml`. API billing is separate from a ChatGPT subscription, and the account must have API billing enabled. OpenAI currently lists `gpt-live-transcribe` at **$0.017 per realtime audio minute**; verify the current rate on the [OpenAI model page](https://developers.openai.com/api/docs/models/gpt-live-transcribe) before deployment.
+
+Run from `app/transcribe`:
+
+```powershell
+python main.py -stt openai-realtime
+```
+
+The `-a`/`--api` switch is not required. That switch continues to mean the existing Whisper file API when `-stt whisper` is selected.
+
+## Audio and source separation
+
+The backend creates one independent WebSocket session per enabled source:
+
+```text
+Microphone -> OpenAI Realtime session -> You
+Windows WASAPI loopback -> OpenAI Realtime session -> Speaker
+```
+
+Each stream is converted independently from its actual device format to mono, signed PCM16 at 24 kHz. Resampling state and incomplete PCM frames are retained across capture-block boundaries to avoid gaps and duplicates. Disabling the microphone or speaker closes only that source's session; pausing transcription closes both sessions.
+
+`Speaker` contains everything played through the selected Windows loopback device. Discord normally mixes all remote participants into that output. Transcribe therefore distinguishes `You` from `Speaker`, but `gpt-live-transcribe` does not identify individual remote participants.
+
+## Partial and final text
+
+OpenAI Realtime emits replaceable transcript deltas and a confirmed `completed` event for each item. Transcribe displays the current partial text through its main-thread UI queue, but only the confirmed transcript is inserted into `Conversation`, the database, LLM context, and **Save Transcript to File** output. Events are reconciled by OpenAI `item_id`, so repeated completion events do not duplicate transcript rows.
+
+## Turn detection
+
+The default uses OpenAI server VAD. It sends audio continuously while OpenAI detects silence and commits each turn:
+
+```yaml
+OpenAIRealtime:
+  turn_detection: 'server_vad'
+  vad_threshold: 0.5
+  vad_prefix_padding_ms: 300
+  vad_silence_duration_ms: 500
+```
+
+Set `turn_detection: null` only for development with an integration that calls the streaming client's manual `commit()` method. The desktop adapter currently uses server VAD.
+
+## Configuration
+
+All Realtime-specific values are separate from LLM response configuration and may be overridden in `override.yaml`:
+
+```yaml
+OpenAIRealtime:
+  model: 'gpt-live-transcribe'
+  input_sample_rate: 24000
+  turn_detection: 'server_vad'
+  delay: 'low'
+  capture_chunk_duration_ms: 100
+  reconnect_attempts: 3
+  reconnect_backoff_seconds: 2
+```
+
+Supported delay presets are `minimal`, `low`, `medium`, `high`, and `xhigh`. Lower delay produces earlier partials; higher delay gives the model more context. The OpenAI API may reject unsupported language codes or invalid keyword hints.
+
+## Reliability, cost, and privacy
+
+- Microphone and speaker sessions reconnect independently with a bounded backoff.
+- Audio waiting for a temporarily disconnected socket is bounded. Buffer overflow is reported as an error rather than hidden.
+- Two enabled sources mean two independently processed live streams and corresponding API usage.
+- Audio is sent to OpenAI for transcription. Review OpenAI's current data controls and your organization's privacy requirements.
+- The application's existing shutdown flow may also save microphone and speaker WAV recordings in its local application-data directory; Realtime mode does not add audio to logs.
+- Inform and obtain any required consent from participants before recording or transcribing them. Laws and workplace policies vary by location.
+- API keys, authorization headers, and raw audio are not written to application logs.
+
+The model does not provide word-level timestamps, confidence scores, or speaker labels. Use one of the existing file/window backends if those features are required.
+
+## Optional live smoke test
+
+Normal tests use simulated WebSockets and require no device, network, key, or paid account. To verify only that a real session can connect and close:
+
+```powershell
+$env:TRANSCRIBE_OPENAI_REALTIME_SMOKE = '1'
+$env:OPENAI_API_KEY = 'YOUR_OPENAI_API_KEY'
+python -m unittest -v app.transcribe.tests.test_openai_realtime_model.TestOpenAIRealtimeSmoke
+```

--- a/docs/OpenAIRealtime.md
+++ b/docs/OpenAIRealtime.md
@@ -40,15 +40,21 @@ OpenAI Realtime emits replaceable transcript deltas and a confirmed `completed` 
 
 ## Turn detection
 
-`gpt-live-transcribe` currently requires automatic turn detection to be disabled.
-Transcribe sends audio continuously and commits it in short, bounded windows so
-confirmed transcript rows keep arriving:
+Transcribe defaults to manual turn detection: it sends audio continuously and
+commits it in short, bounded windows so confirmed transcript rows keep arriving
+predictably:
 
 ```yaml
 OpenAIRealtime:
   turn_detection: null
   manual_commit_interval_seconds: 3
 ```
+
+OpenAI Realtime also supports server voice activity detection. Set
+`turn_detection: server_vad` to create turns at detected silence boundaries;
+the `vad_threshold`, `vad_prefix_padding_ms`, and `vad_silence_duration_ms`
+settings then control that behavior. `manual_commit_interval_seconds` applies
+only when server VAD is disabled.
 
 ## Configuration
 

--- a/docs/OpenAIRealtime.md
+++ b/docs/OpenAIRealtime.md
@@ -40,17 +40,15 @@ OpenAI Realtime emits replaceable transcript deltas and a confirmed `completed` 
 
 ## Turn detection
 
-The default uses OpenAI server VAD. It sends audio continuously while OpenAI detects silence and commits each turn:
+`gpt-live-transcribe` currently requires automatic turn detection to be disabled.
+Transcribe sends audio continuously and commits it in short, bounded windows so
+confirmed transcript rows keep arriving:
 
 ```yaml
 OpenAIRealtime:
-  turn_detection: 'server_vad'
-  vad_threshold: 0.5
-  vad_prefix_padding_ms: 300
-  vad_silence_duration_ms: 500
+  turn_detection: null
+  manual_commit_interval_seconds: 3
 ```
-
-Set `turn_detection: null` only for development with an integration that calls the streaming client's manual `commit()` method. The desktop adapter currently uses server VAD.
 
 ## Configuration
 
@@ -60,7 +58,8 @@ All Realtime-specific values are separate from LLM response configuration and ma
 OpenAIRealtime:
   model: 'gpt-live-transcribe'
   input_sample_rate: 24000
-  turn_detection: 'server_vad'
+  turn_detection: null
+  manual_commit_interval_seconds: 3
   delay: 'low'
   capture_chunk_duration_ms: 100
   reconnect_attempts: 3
@@ -70,6 +69,11 @@ OpenAIRealtime:
   event_queue_size: 500
   deduplication_cache_size: 2048
 ```
+
+Before each WebSocket connection, Transcribe creates a short-lived OpenAI client
+secret bound to a `type: transcription` session. The standard API key is used
+only for that credential request; the socket authenticates with the ephemeral
+secret and `model` is sent as `audio.input.transcription.model`.
 
 Supported delay presets are `minimal`, `low`, `medium`, `high`, and `xhigh`. Lower delay produces earlier partials; higher delay gives the model more context. The OpenAI API may reject unsupported language codes or invalid keyword hints.
 

--- a/docs/Providers.md
+++ b/docs/Providers.md
@@ -17,6 +17,8 @@ OpenAI:
 Default `base_url` for OpenAI is `https://api.openai.com/v1`
 Default `ai_model` for OpenAI is `gpt-5.4-mini`
 
+This compatibility configuration applies to response generation. The optional `openai-realtime` STT backend connects specifically to OpenAI's Realtime WebSocket API and is configured separately under `OpenAIRealtime`; it should not be confused with the Whisper API selected by `-stt whisper --api`.
+
 Our users have found this to be very useful in countries like Australia and China, where they cannot access the default providers directly or it is cost prohibitive to access these providers.
 
 ## Deepgram Speech To Text

--- a/sdk/audio_recorder.py
+++ b/sdk/audio_recorder.py
@@ -198,7 +198,15 @@ class BaseRecorder:
         return stop_capture
 
     def _enqueue_audio(self, audio_queue: queue.Queue, data: bytes):
-        audio_queue.put((self.source_name, data, datetime.utcnow()))
+        audio_item = (self.source_name, data, datetime.utcnow())
+        try:
+            audio_queue.put_nowait(audio_item)
+        except queue.Full:
+            try:
+                audio_queue.get_nowait()
+                audio_queue.put_nowait(audio_item)
+            except (queue.Empty, queue.Full):
+                logger.warning("Audio ingress buffer remained full for %s; newest block was dropped", self.source_name)
         if self.audio_file_name:
             with open(file=self.audio_file_name+'.bak', mode='ab') as file_handle:
                 file_handle.write(data)

--- a/sdk/audio_recorder.py
+++ b/sdk/audio_recorder.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import queue
+import threading
 import time
 import wave
 from datetime import datetime
@@ -147,19 +148,60 @@ class BaseRecorder:
     def record_audio(self, audio_queue: queue.Queue):
         """Start recording audion from the stream and add data to queue
         """
+        if self.config["General"].get("stt", "").lower() == "openai-realtime":
+            return self._record_audio_continuously(audio_queue)
+
         def record_callback(_, audio: sr.AudioData) -> None:
             if self.enabled:
                 data = audio.get_raw_data()
-                audio_queue.put((self.source_name, data, datetime.utcnow()))
-                if self.audio_file_name:
-                    with open(file=self.audio_file_name+'.bak', mode='ab') as file_handle:
-                        file_handle.write(data)
+                self._enqueue_audio(audio_queue, data)
 
         stop_func = self.recorder.listen_in_background(source=self.source,
                                                        source_name=self.source_name,
                                                        callback=record_callback,
                                                        phrase_time_limit=self.config['General']['transcript_audio_duration_seconds'])
         return stop_func
+
+    def _record_audio_continuously(self, audio_queue: queue.Queue):
+        """Capture raw PCM blocks continuously for persistent streaming providers."""
+        stop_event = threading.Event()
+        chunk_duration_ms = int(
+            self.config.get("OpenAIRealtime", {}).get("capture_chunk_duration_ms", 100)
+        )
+        chunk_frames = max(1, int(self.source.SAMPLE_RATE * chunk_duration_ms / 1000))
+
+        def capture_loop():
+            try:
+                with self.source as active_source:
+                    while not stop_event.is_set():
+                        data = active_source.stream.read(chunk_frames)
+                        if not data:
+                            break
+                        if self.enabled:
+                            self._enqueue_audio(audio_queue, data)
+            except Exception as exception:
+                if not stop_event.is_set():
+                    logger.error("Continuous capture failed for %s: %s", self.source_name, exception)
+
+        capture_thread = threading.Thread(
+            target=capture_loop,
+            name=f"{self.source_name} Streaming Thread",
+            daemon=True,
+        )
+        capture_thread.start()
+
+        def stop_capture(wait_for_stop=True):
+            stop_event.set()
+            if wait_for_stop and capture_thread.is_alive():
+                capture_thread.join(timeout=2)
+
+        return stop_capture
+
+    def _enqueue_audio(self, audio_queue: queue.Queue, data: bytes):
+        audio_queue.put((self.source_name, data, datetime.utcnow()))
+        if self.audio_file_name:
+            with open(file=self.audio_file_name+'.bak', mode='ab') as file_handle:
+                file_handle.write(data)
 
     def write_wav_data_to_file(self) -> str:
         """Write the raw input data into a wave file

--- a/sdk/streaming_transcriber_models.py
+++ b/sdk/streaming_transcriber_models.py
@@ -1,0 +1,444 @@
+"""Provider-neutral streaming STT contracts and OpenAI Realtime support."""
+
+from __future__ import annotations
+
+import audioop
+import base64
+import json
+import queue
+import re
+import threading
+import time
+from abc import ABC, abstractmethod
+from array import array
+from urllib.parse import quote
+
+
+OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime"
+TRANSCRIPT_DELTA_EVENT = "conversation.item.input_audio_transcription.delta"
+TRANSCRIPT_COMPLETED_EVENT = "conversation.item.input_audio_transcription.completed"
+
+
+class StreamingSTTModelInterface(ABC):
+    """Contract for STT providers that keep a persistent streaming session."""
+
+    @abstractmethod
+    def start(self):
+        """Open the provider session and start its background workers."""
+
+    @abstractmethod
+    def append_audio(self, audio: bytes):
+        """Append source-format PCM audio to the persistent session."""
+
+    @abstractmethod
+    def commit(self):
+        """Commit the current input turn when automatic turn detection is disabled."""
+
+    @abstractmethod
+    def stop(self):
+        """Close the provider session and all background workers."""
+
+    @abstractmethod
+    def set_partial_callback(self, callback):
+        """Set callback(source, item_id, text) for replaceable partial text."""
+
+    @abstractmethod
+    def set_completed_callback(self, callback):
+        """Set callback(source, item_id, text) for confirmed transcript text."""
+
+    @abstractmethod
+    def set_error_callback(self, callback):
+        """Set callback(source, sanitized_message) for provider errors."""
+
+
+class PCM16MonoResampler:
+    """Incrementally convert arbitrary interleaved PCM into 24 kHz mono PCM16."""
+
+    def __init__(self, sample_rate: int, sample_width: int, channels: int, target_rate: int = 24000):
+        if sample_rate <= 0 or sample_width not in (1, 2, 3, 4) or channels <= 0:
+            raise ValueError("Invalid PCM source format")
+        self.sample_rate = int(sample_rate)
+        self.sample_width = int(sample_width)
+        self.channels = int(channels)
+        self.target_rate = int(target_rate)
+        self._pending = b""
+        self._rate_state = None
+        self._lock = threading.Lock()
+
+    def convert(self, audio: bytes) -> bytes:
+        """Convert a chunk without losing partial frames at chunk boundaries."""
+        if not audio:
+            return b""
+        with self._lock:
+            framed = self._pending + bytes(audio)
+            frame_size = self.sample_width * self.channels
+            complete_size = len(framed) - (len(framed) % frame_size)
+            if complete_size <= 0:
+                self._pending = framed
+                return b""
+            complete = framed[:complete_size]
+            self._pending = framed[complete_size:]
+
+            if self.sample_width == 1:
+                complete = audioop.bias(complete, 1, -128)
+            pcm16 = audioop.lin2lin(complete, self.sample_width, 2)
+            mono = self._to_mono(pcm16)
+            if self.sample_rate == self.target_rate:
+                return mono
+            converted, self._rate_state = audioop.ratecv(
+                mono,
+                2,
+                1,
+                self.sample_rate,
+                self.target_rate,
+                self._rate_state,
+            )
+            return converted
+
+    def reset(self):
+        """Drop incomplete input and resampler history after an explicit stream reset."""
+        with self._lock:
+            self._pending = b""
+            self._rate_state = None
+
+    def _to_mono(self, pcm16: bytes) -> bytes:
+        if self.channels == 1:
+            return pcm16
+        if self.channels == 2:
+            return audioop.tomono(pcm16, 2, 0.5, 0.5)
+
+        samples = array("h")
+        samples.frombytes(pcm16)
+        mono = array("h")
+        for offset in range(0, len(samples), self.channels):
+            frame = samples[offset:offset + self.channels]
+            mono.append(int(sum(frame) / len(frame)))
+        return mono.tobytes()
+
+
+class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
+    """One persistent OpenAI Realtime transcription session for one audio source."""
+
+    def __init__(
+        self,
+        source_name: str,
+        source_format: dict,
+        config: dict,
+        websocket_app_factory=None,
+        sleep_func=time.sleep,
+    ):
+        api_key = str(config.get("api_key") or "").strip()
+        if not api_key or api_key == "API_KEY":
+            raise ValueError("OpenAI Realtime transcription requires an OpenAI API key.")
+
+        self.source_name = source_name
+        self.api_key = api_key
+        self.model = config.get("model", "gpt-live-transcribe")
+        self.input_sample_rate = int(config.get("input_sample_rate", 24000))
+        self.turn_detection = config.get("turn_detection", "server_vad")
+        self.reconnect_attempts = max(0, int(config.get("reconnect_attempts", 3)))
+        self.reconnect_backoff_seconds = max(0.0, float(config.get("reconnect_backoff_seconds", 2)))
+        self.max_buffered_chunks = max(1, int(config.get("max_buffered_chunks", 120)))
+        self.transcription_delay = config.get("delay", "low")
+        self.languages = list(config.get("languages") or [])
+        self.prompt = str(config.get("prompt") or "").strip()
+        self.keywords = list(config.get("keywords") or [])
+        self.vad_threshold = float(config.get("vad_threshold", 0.5))
+        self.vad_prefix_padding_ms = int(config.get("vad_prefix_padding_ms", 300))
+        self.vad_silence_duration_ms = int(config.get("vad_silence_duration_ms", 500))
+
+        self._converter = PCM16MonoResampler(
+            sample_rate=int(source_format["sample_rate"]),
+            sample_width=int(source_format["sample_width"]),
+            channels=int(source_format["channels"]),
+            target_rate=self.input_sample_rate,
+        )
+        self._websocket_app_factory = websocket_app_factory or self._default_websocket_app_factory
+        self._sleep = sleep_func
+        self._audio_queue: queue.Queue = queue.Queue(maxsize=self.max_buffered_chunks)
+        self._stop_event = threading.Event()
+        self._connected_event = threading.Event()
+        self._lifecycle_lock = threading.Lock()
+        self._websocket = None
+        self._connection_thread = None
+        self._sender_thread = None
+        self._partial_by_item: dict[str, str] = {}
+        self._completed_items: set[str] = set()
+        self._partial_callback = None
+        self._completed_callback = None
+        self._error_callback = None
+
+    @staticmethod
+    def _default_websocket_app_factory(*args, **kwargs):
+        import websocket  # pylint: disable=import-outside-toplevel
+        return websocket.WebSocketApp(*args, **kwargs)
+
+    def start(self):
+        """Start connection and sender workers once; safe to call repeatedly."""
+        with self._lifecycle_lock:
+            if self._connection_thread and self._connection_thread.is_alive():
+                return
+            self._stop_event.clear()
+            self._connection_thread = threading.Thread(
+                target=self._connection_loop,
+                name=f"OpenAIRealtime-{self.source_name}",
+                daemon=True,
+            )
+            self._sender_thread = threading.Thread(
+                target=self._sender_loop,
+                name=f"OpenAIRealtimeSender-{self.source_name}",
+                daemon=True,
+            )
+            self._connection_thread.start()
+            self._sender_thread.start()
+
+    def append_audio(self, audio: bytes):
+        """Normalize source audio and enqueue it without allowing unbounded growth."""
+        converted = self._converter.convert(audio)
+        if not converted:
+            return
+        try:
+            self._audio_queue.put_nowait(converted)
+        except queue.Full:
+            self._emit_error(
+                "Realtime audio buffer is full; the connection is not keeping up and audio was not queued."
+            )
+
+    def commit(self):
+        """Commit the current input buffer for manual-turn configurations."""
+        self._send_event({"type": "input_audio_buffer.commit"})
+
+    def clear_audio(self):
+        """Clear queued and server-side uncommitted audio."""
+        self._drain_queue(self._audio_queue)
+        self._converter.reset()
+        self._partial_by_item.clear()
+        if self._connected_event.is_set():
+            try:
+                self._send_event({"type": "input_audio_buffer.clear"})
+            except Exception as exception:  # network state may change between the check and send
+                self._emit_error(exception)
+
+    def stop(self):
+        """Stop workers and close the socket without leaving non-daemon resources."""
+        with self._lifecycle_lock:
+            self._stop_event.set()
+            self._connected_event.set()
+            websocket_app = self._websocket
+            if websocket_app is not None:
+                try:
+                    websocket_app.close()
+                except Exception as exception:  # close is best effort
+                    self._emit_error(exception)
+            current = threading.current_thread()
+            for worker in (self._sender_thread, self._connection_thread):
+                if worker and worker is not current and worker.is_alive():
+                    worker.join(timeout=2)
+            self._connected_event.clear()
+            self._drain_queue(self._audio_queue)
+            self._converter.reset()
+            self._partial_by_item.clear()
+
+    def set_partial_callback(self, callback):
+        self._partial_callback = callback
+
+    def set_completed_callback(self, callback):
+        self._completed_callback = callback
+
+    def set_error_callback(self, callback):
+        self._error_callback = callback
+
+    def set_languages(self, languages: list[str]):
+        """Update expected languages for future and active transcription turns."""
+        self.languages = list(languages or [])
+        if self._connected_event.is_set():
+            self._send_event(self._session_update_event())
+
+    def configure_source(self, source_format: dict):
+        """Replace the incremental converter when the selected device format changes."""
+        self._converter = PCM16MonoResampler(
+            sample_rate=int(source_format["sample_rate"]),
+            sample_width=int(source_format["sample_width"]),
+            channels=int(source_format["channels"]),
+            target_rate=self.input_sample_rate,
+        )
+
+    @property
+    def connected(self) -> bool:
+        return self._connected_event.is_set() and not self._stop_event.is_set()
+
+    def _connection_loop(self):
+        url = f"{OPENAI_REALTIME_URL}?model={quote(self.model)}"
+        headers = [f"Authorization: Bearer {self.api_key}"]
+        total_attempts = self.reconnect_attempts + 1
+        for attempt in range(total_attempts):
+            if self._stop_event.is_set():
+                return
+            if attempt:
+                self._emit_error(f"Realtime connection retry {attempt}/{self.reconnect_attempts}.")
+                self._sleep(self.reconnect_backoff_seconds * attempt)
+                if self._stop_event.is_set():
+                    return
+            try:
+                websocket_app = self._websocket_app_factory(
+                    url,
+                    header=headers,
+                    on_open=self._on_open,
+                    on_message=self._on_message,
+                    on_error=self._on_error,
+                    on_close=self._on_close,
+                )
+                self._websocket = websocket_app
+                websocket_app.run_forever()
+            except Exception as exception:
+                self._emit_error(exception)
+            finally:
+                self._connected_event.clear()
+                self._websocket = None
+            if self._stop_event.is_set():
+                return
+        self._emit_error("Realtime connection stopped after the configured retry limit.")
+
+    def _sender_loop(self):
+        pending = None
+        while not self._stop_event.is_set():
+            if pending is None:
+                try:
+                    pending = self._audio_queue.get(timeout=0.1)
+                except queue.Empty:
+                    continue
+            if not self._connected_event.wait(timeout=0.1):
+                continue
+            if self._stop_event.is_set():
+                return
+            try:
+                self._send_event(
+                    {
+                        "type": "input_audio_buffer.append",
+                        "audio": base64.b64encode(pending).decode("ascii"),
+                    }
+                )
+                pending = None
+            except Exception as exception:
+                self._connected_event.clear()
+                self._emit_error(f"Audio send failed; reconnecting ({exception.__class__.__name__}).")
+                websocket_app = self._websocket
+                if websocket_app is not None:
+                    try:
+                        websocket_app.close()
+                    except Exception:
+                        pass
+
+    def _on_open(self, websocket_app):
+        try:
+            websocket_app.send(json.dumps(self._session_update_event()))
+            self._connected_event.set()
+        except Exception as exception:
+            self._emit_error(exception)
+            websocket_app.close()
+
+    def _on_message(self, _websocket_app, message):
+        try:
+            event = json.loads(message)
+        except (TypeError, json.JSONDecodeError):
+            self._emit_error("Realtime server returned an invalid JSON event.")
+            return
+
+        event_type = event.get("type")
+        if event_type == TRANSCRIPT_DELTA_EVENT:
+            item_id = str(event.get("item_id") or "")
+            if not item_id or item_id in self._completed_items:
+                return
+            delta = str(event.get("delta") or "")
+            current = self._partial_by_item.get(item_id, "")
+            updated = self._merge_delta(current, delta)
+            self._partial_by_item[item_id] = updated
+            if updated and self._partial_callback:
+                self._partial_callback(self.source_name, item_id, updated)
+        elif event_type == TRANSCRIPT_COMPLETED_EVENT:
+            item_id = str(event.get("item_id") or "")
+            if not item_id or item_id in self._completed_items:
+                return
+            self._completed_items.add(item_id)
+            final_text = str(event.get("transcript") or "").strip()
+            self._partial_by_item.pop(item_id, None)
+            if final_text and self._completed_callback:
+                self._completed_callback(self.source_name, item_id, final_text)
+        elif event_type in ("error", "conversation.item.input_audio_transcription.failed"):
+            error = event.get("error") or {}
+            self._emit_error(error.get("message") or error.get("code") or "Realtime transcription failed.")
+
+    def _on_error(self, _websocket_app, error):
+        if not self._stop_event.is_set():
+            self._emit_error(error)
+
+    def _on_close(self, _websocket_app, _status_code, _message):
+        self._connected_event.clear()
+
+    def _session_update_event(self) -> dict:
+        transcription = {"model": self.model, "delay": self.transcription_delay}
+        if self.languages:
+            transcription["languages"] = self.languages
+        if self.prompt:
+            transcription["prompt"] = self.prompt
+        if self.keywords:
+            transcription["keywords"] = self.keywords
+
+        turn_detection = None
+        if self.turn_detection == "server_vad":
+            turn_detection = {
+                "type": "server_vad",
+                "threshold": self.vad_threshold,
+                "prefix_padding_ms": self.vad_prefix_padding_ms,
+                "silence_duration_ms": self.vad_silence_duration_ms,
+            }
+
+        return {
+            "type": "session.update",
+            "session": {
+                "type": "transcription",
+                "audio": {
+                    "input": {
+                        "format": {"type": "audio/pcm", "rate": self.input_sample_rate},
+                        "transcription": transcription,
+                        "turn_detection": turn_detection,
+                    }
+                },
+            },
+        }
+
+    def _send_event(self, event: dict):
+        websocket_app = self._websocket
+        if websocket_app is None:
+            raise ConnectionError("Realtime WebSocket is not connected.")
+        websocket_app.send(json.dumps(event))
+
+    def _emit_error(self, error):
+        message = self._sanitize_error(error)
+        if self._error_callback:
+            self._error_callback(self.source_name, message)
+
+    @staticmethod
+    def _sanitize_error(error) -> str:
+        message = str(error or "Unknown Realtime transcription error.")
+        message = re.sub(r"Bearer\s+\S+", "Bearer [REDACTED]", message, flags=re.IGNORECASE)
+        message = re.sub(r"sk-[A-Za-z0-9_-]+", "[REDACTED]", message)
+        return message[:500]
+
+    @staticmethod
+    def _merge_delta(current: str, delta: str) -> str:
+        if not delta:
+            return current
+        if delta == current:
+            return current
+        if delta.startswith(current):
+            return delta
+        return current + delta
+
+    @staticmethod
+    def _drain_queue(target_queue: queue.Queue):
+        try:
+            while True:
+                target_queue.get_nowait()
+        except queue.Empty:
+            pass

--- a/sdk/streaming_transcriber_models.py
+++ b/sdk/streaming_transcriber_models.py
@@ -1,33 +1,41 @@
-"""Provider-neutral streaming STT contracts and OpenAI Realtime support."""
+"""Provider-neutral contracts and audio conversion for streaming STT."""
 
 from __future__ import annotations
 
 import audioop
-import base64
-import json
-import queue
-import re
 import threading
-import time
 from abc import ABC, abstractmethod
 from array import array
-from urllib.parse import quote
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
 
 
-OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime"
-TRANSCRIPT_DELTA_EVENT = "conversation.item.input_audio_transcription.delta"
-TRANSCRIPT_COMPLETED_EVENT = "conversation.item.input_audio_transcription.completed"
+class TranscriptEventKind(Enum):
+    PARTIAL = "partial"
+    COMPLETED = "completed"
+
+
+@dataclass(frozen=True)
+class StreamingTranscriptEvent:
+    """One provider-addressable streaming transcription update."""
+
+    kind: TranscriptEventKind
+    source: str
+    item_id: str
+    text: str
+    time_spoken: datetime | None = None
 
 
 class StreamingSTTModelInterface(ABC):
-    """Contract for STT providers that keep a persistent streaming session."""
+    """Contract for providers that keep a persistent streaming session."""
 
     @abstractmethod
     def start(self):
         """Open the provider session and start its background workers."""
 
     @abstractmethod
-    def append_audio(self, audio: bytes):
+    def append_audio(self, audio: bytes, captured_at=None):
         """Append source-format PCM audio to the persistent session."""
 
     @abstractmethod
@@ -39,12 +47,8 @@ class StreamingSTTModelInterface(ABC):
         """Close the provider session and all background workers."""
 
     @abstractmethod
-    def set_partial_callback(self, callback):
-        """Set callback(source, item_id, text) for replaceable partial text."""
-
-    @abstractmethod
-    def set_completed_callback(self, callback):
-        """Set callback(source, item_id, text) for confirmed transcript text."""
+    def set_transcript_callback(self, callback):
+        """Set callback(event) for provider-addressable transcript updates."""
 
     @abstractmethod
     def set_error_callback(self, callback):
@@ -52,7 +56,7 @@ class StreamingSTTModelInterface(ABC):
 
 
 class PCM16MonoResampler:
-    """Incrementally convert arbitrary interleaved PCM into 24 kHz mono PCM16."""
+    """Incrementally convert arbitrary interleaved PCM into mono PCM16."""
 
     def __init__(self, sample_rate: int, sample_width: int, channels: int, target_rate: int = 24000):
         if sample_rate <= 0 or sample_width not in (1, 2, 3, 4) or channels <= 0:
@@ -86,17 +90,12 @@ class PCM16MonoResampler:
             if self.sample_rate == self.target_rate:
                 return mono
             converted, self._rate_state = audioop.ratecv(
-                mono,
-                2,
-                1,
-                self.sample_rate,
-                self.target_rate,
-                self._rate_state,
+                mono, 2, 1, self.sample_rate, self.target_rate, self._rate_state
             )
             return converted
 
     def reset(self):
-        """Drop incomplete input and resampler history after an explicit stream reset."""
+        """Drop incomplete input and resampler history after a stream reset."""
         with self._lock:
             self._pending = b""
             self._rate_state = None
@@ -114,331 +113,3 @@ class PCM16MonoResampler:
             frame = samples[offset:offset + self.channels]
             mono.append(int(sum(frame) / len(frame)))
         return mono.tobytes()
-
-
-class OpenAIRealtimeSTTModel(StreamingSTTModelInterface):
-    """One persistent OpenAI Realtime transcription session for one audio source."""
-
-    def __init__(
-        self,
-        source_name: str,
-        source_format: dict,
-        config: dict,
-        websocket_app_factory=None,
-        sleep_func=time.sleep,
-    ):
-        api_key = str(config.get("api_key") or "").strip()
-        if not api_key or api_key == "API_KEY":
-            raise ValueError("OpenAI Realtime transcription requires an OpenAI API key.")
-
-        self.source_name = source_name
-        self.api_key = api_key
-        self.model = config.get("model", "gpt-live-transcribe")
-        self.input_sample_rate = int(config.get("input_sample_rate", 24000))
-        self.turn_detection = config.get("turn_detection", "server_vad")
-        self.reconnect_attempts = max(0, int(config.get("reconnect_attempts", 3)))
-        self.reconnect_backoff_seconds = max(0.0, float(config.get("reconnect_backoff_seconds", 2)))
-        self.max_buffered_chunks = max(1, int(config.get("max_buffered_chunks", 120)))
-        self.transcription_delay = config.get("delay", "low")
-        self.languages = list(config.get("languages") or [])
-        self.prompt = str(config.get("prompt") or "").strip()
-        self.keywords = list(config.get("keywords") or [])
-        self.vad_threshold = float(config.get("vad_threshold", 0.5))
-        self.vad_prefix_padding_ms = int(config.get("vad_prefix_padding_ms", 300))
-        self.vad_silence_duration_ms = int(config.get("vad_silence_duration_ms", 500))
-
-        self._converter = PCM16MonoResampler(
-            sample_rate=int(source_format["sample_rate"]),
-            sample_width=int(source_format["sample_width"]),
-            channels=int(source_format["channels"]),
-            target_rate=self.input_sample_rate,
-        )
-        self._websocket_app_factory = websocket_app_factory or self._default_websocket_app_factory
-        self._sleep = sleep_func
-        self._audio_queue: queue.Queue = queue.Queue(maxsize=self.max_buffered_chunks)
-        self._stop_event = threading.Event()
-        self._connected_event = threading.Event()
-        self._lifecycle_lock = threading.Lock()
-        self._websocket = None
-        self._connection_thread = None
-        self._sender_thread = None
-        self._partial_by_item: dict[str, str] = {}
-        self._completed_items: set[str] = set()
-        self._partial_callback = None
-        self._completed_callback = None
-        self._error_callback = None
-
-    @staticmethod
-    def _default_websocket_app_factory(*args, **kwargs):
-        import websocket  # pylint: disable=import-outside-toplevel
-        return websocket.WebSocketApp(*args, **kwargs)
-
-    def start(self):
-        """Start connection and sender workers once; safe to call repeatedly."""
-        with self._lifecycle_lock:
-            if self._connection_thread and self._connection_thread.is_alive():
-                return
-            self._stop_event.clear()
-            self._connection_thread = threading.Thread(
-                target=self._connection_loop,
-                name=f"OpenAIRealtime-{self.source_name}",
-                daemon=True,
-            )
-            self._sender_thread = threading.Thread(
-                target=self._sender_loop,
-                name=f"OpenAIRealtimeSender-{self.source_name}",
-                daemon=True,
-            )
-            self._connection_thread.start()
-            self._sender_thread.start()
-
-    def append_audio(self, audio: bytes):
-        """Normalize source audio and enqueue it without allowing unbounded growth."""
-        converted = self._converter.convert(audio)
-        if not converted:
-            return
-        try:
-            self._audio_queue.put_nowait(converted)
-        except queue.Full:
-            self._emit_error(
-                "Realtime audio buffer is full; the connection is not keeping up and audio was not queued."
-            )
-
-    def commit(self):
-        """Commit the current input buffer for manual-turn configurations."""
-        self._send_event({"type": "input_audio_buffer.commit"})
-
-    def clear_audio(self):
-        """Clear queued and server-side uncommitted audio."""
-        self._drain_queue(self._audio_queue)
-        self._converter.reset()
-        self._partial_by_item.clear()
-        if self._connected_event.is_set():
-            try:
-                self._send_event({"type": "input_audio_buffer.clear"})
-            except Exception as exception:  # network state may change between the check and send
-                self._emit_error(exception)
-
-    def stop(self):
-        """Stop workers and close the socket without leaving non-daemon resources."""
-        with self._lifecycle_lock:
-            self._stop_event.set()
-            self._connected_event.set()
-            websocket_app = self._websocket
-            if websocket_app is not None:
-                try:
-                    websocket_app.close()
-                except Exception as exception:  # close is best effort
-                    self._emit_error(exception)
-            current = threading.current_thread()
-            for worker in (self._sender_thread, self._connection_thread):
-                if worker and worker is not current and worker.is_alive():
-                    worker.join(timeout=2)
-            self._connected_event.clear()
-            self._drain_queue(self._audio_queue)
-            self._converter.reset()
-            self._partial_by_item.clear()
-
-    def set_partial_callback(self, callback):
-        self._partial_callback = callback
-
-    def set_completed_callback(self, callback):
-        self._completed_callback = callback
-
-    def set_error_callback(self, callback):
-        self._error_callback = callback
-
-    def set_languages(self, languages: list[str]):
-        """Update expected languages for future and active transcription turns."""
-        self.languages = list(languages or [])
-        if self._connected_event.is_set():
-            self._send_event(self._session_update_event())
-
-    def configure_source(self, source_format: dict):
-        """Replace the incremental converter when the selected device format changes."""
-        self._converter = PCM16MonoResampler(
-            sample_rate=int(source_format["sample_rate"]),
-            sample_width=int(source_format["sample_width"]),
-            channels=int(source_format["channels"]),
-            target_rate=self.input_sample_rate,
-        )
-
-    @property
-    def connected(self) -> bool:
-        return self._connected_event.is_set() and not self._stop_event.is_set()
-
-    def _connection_loop(self):
-        url = f"{OPENAI_REALTIME_URL}?model={quote(self.model)}"
-        headers = [f"Authorization: Bearer {self.api_key}"]
-        total_attempts = self.reconnect_attempts + 1
-        for attempt in range(total_attempts):
-            if self._stop_event.is_set():
-                return
-            if attempt:
-                self._emit_error(f"Realtime connection retry {attempt}/{self.reconnect_attempts}.")
-                self._sleep(self.reconnect_backoff_seconds * attempt)
-                if self._stop_event.is_set():
-                    return
-            try:
-                websocket_app = self._websocket_app_factory(
-                    url,
-                    header=headers,
-                    on_open=self._on_open,
-                    on_message=self._on_message,
-                    on_error=self._on_error,
-                    on_close=self._on_close,
-                )
-                self._websocket = websocket_app
-                websocket_app.run_forever()
-            except Exception as exception:
-                self._emit_error(exception)
-            finally:
-                self._connected_event.clear()
-                self._websocket = None
-            if self._stop_event.is_set():
-                return
-        self._emit_error("Realtime connection stopped after the configured retry limit.")
-
-    def _sender_loop(self):
-        pending = None
-        while not self._stop_event.is_set():
-            if pending is None:
-                try:
-                    pending = self._audio_queue.get(timeout=0.1)
-                except queue.Empty:
-                    continue
-            if not self._connected_event.wait(timeout=0.1):
-                continue
-            if self._stop_event.is_set():
-                return
-            try:
-                self._send_event(
-                    {
-                        "type": "input_audio_buffer.append",
-                        "audio": base64.b64encode(pending).decode("ascii"),
-                    }
-                )
-                pending = None
-            except Exception as exception:
-                self._connected_event.clear()
-                self._emit_error(f"Audio send failed; reconnecting ({exception.__class__.__name__}).")
-                websocket_app = self._websocket
-                if websocket_app is not None:
-                    try:
-                        websocket_app.close()
-                    except Exception:
-                        pass
-
-    def _on_open(self, websocket_app):
-        try:
-            websocket_app.send(json.dumps(self._session_update_event()))
-            self._connected_event.set()
-        except Exception as exception:
-            self._emit_error(exception)
-            websocket_app.close()
-
-    def _on_message(self, _websocket_app, message):
-        try:
-            event = json.loads(message)
-        except (TypeError, json.JSONDecodeError):
-            self._emit_error("Realtime server returned an invalid JSON event.")
-            return
-
-        event_type = event.get("type")
-        if event_type == TRANSCRIPT_DELTA_EVENT:
-            item_id = str(event.get("item_id") or "")
-            if not item_id or item_id in self._completed_items:
-                return
-            delta = str(event.get("delta") or "")
-            current = self._partial_by_item.get(item_id, "")
-            updated = self._merge_delta(current, delta)
-            self._partial_by_item[item_id] = updated
-            if updated and self._partial_callback:
-                self._partial_callback(self.source_name, item_id, updated)
-        elif event_type == TRANSCRIPT_COMPLETED_EVENT:
-            item_id = str(event.get("item_id") or "")
-            if not item_id or item_id in self._completed_items:
-                return
-            self._completed_items.add(item_id)
-            final_text = str(event.get("transcript") or "").strip()
-            self._partial_by_item.pop(item_id, None)
-            if final_text and self._completed_callback:
-                self._completed_callback(self.source_name, item_id, final_text)
-        elif event_type in ("error", "conversation.item.input_audio_transcription.failed"):
-            error = event.get("error") or {}
-            self._emit_error(error.get("message") or error.get("code") or "Realtime transcription failed.")
-
-    def _on_error(self, _websocket_app, error):
-        if not self._stop_event.is_set():
-            self._emit_error(error)
-
-    def _on_close(self, _websocket_app, _status_code, _message):
-        self._connected_event.clear()
-
-    def _session_update_event(self) -> dict:
-        transcription = {"model": self.model, "delay": self.transcription_delay}
-        if self.languages:
-            transcription["languages"] = self.languages
-        if self.prompt:
-            transcription["prompt"] = self.prompt
-        if self.keywords:
-            transcription["keywords"] = self.keywords
-
-        turn_detection = None
-        if self.turn_detection == "server_vad":
-            turn_detection = {
-                "type": "server_vad",
-                "threshold": self.vad_threshold,
-                "prefix_padding_ms": self.vad_prefix_padding_ms,
-                "silence_duration_ms": self.vad_silence_duration_ms,
-            }
-
-        return {
-            "type": "session.update",
-            "session": {
-                "type": "transcription",
-                "audio": {
-                    "input": {
-                        "format": {"type": "audio/pcm", "rate": self.input_sample_rate},
-                        "transcription": transcription,
-                        "turn_detection": turn_detection,
-                    }
-                },
-            },
-        }
-
-    def _send_event(self, event: dict):
-        websocket_app = self._websocket
-        if websocket_app is None:
-            raise ConnectionError("Realtime WebSocket is not connected.")
-        websocket_app.send(json.dumps(event))
-
-    def _emit_error(self, error):
-        message = self._sanitize_error(error)
-        if self._error_callback:
-            self._error_callback(self.source_name, message)
-
-    @staticmethod
-    def _sanitize_error(error) -> str:
-        message = str(error or "Unknown Realtime transcription error.")
-        message = re.sub(r"Bearer\s+\S+", "Bearer [REDACTED]", message, flags=re.IGNORECASE)
-        message = re.sub(r"sk-[A-Za-z0-9_-]+", "[REDACTED]", message)
-        return message[:500]
-
-    @staticmethod
-    def _merge_delta(current: str, delta: str) -> str:
-        if not delta:
-            return current
-        if delta == current:
-            return current
-        if delta.startswith(current):
-            return delta
-        return current + delta
-
-    @staticmethod
-    def _drain_queue(target_queue: queue.Queue):
-        try:
-            while True:
-                target_queue.get_nowait()
-        except queue.Empty:
-            pass

--- a/tsutils/tests/test_utilities.py
+++ b/tsutils/tests/test_utilities.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 import openai
 from tsutils.utilities import (
@@ -58,6 +59,42 @@ class TestFunctions(unittest.TestCase):
             base_url='https://api.example.com',
             model='unavailable-model',
         ))
+
+    @patch('tsutils.utilities.openai.OpenAI')
+    def test_is_api_key_valid_uses_modern_token_limit_for_gpt_5(self, mock_openai):
+        utilities.valid_api_key = False
+        client = mock_openai.return_value
+        client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content='online'))]
+        )
+
+        self.assertTrue(is_api_key_valid(
+            api_key='key',
+            base_url='https://api.openai.com/v1',
+            model='gpt-5.4-mini',
+        ))
+
+        request_args = client.chat.completions.create.call_args.kwargs
+        self.assertEqual(request_args['max_completion_tokens'], 1024)
+        self.assertNotIn('max_tokens', request_args)
+
+    @patch('tsutils.utilities.openai.OpenAI')
+    def test_is_api_key_valid_preserves_legacy_provider_token_limit(self, mock_openai):
+        utilities.valid_api_key = False
+        client = mock_openai.return_value
+        client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content='online'))]
+        )
+
+        self.assertTrue(is_api_key_valid(
+            api_key='key',
+            base_url='https://api.example.com',
+            model='legacy-chat-model',
+        ))
+
+        request_args = client.chat.completions.create.call_args.kwargs
+        self.assertEqual(request_args['max_tokens'], 1024)
+        self.assertNotIn('max_completion_tokens', request_args)
 
 
 if __name__ == '__main__':

--- a/tsutils/utilities.py
+++ b/tsutils/utilities.py
@@ -230,8 +230,8 @@ def is_api_key_valid(api_key: str, base_url: str, model: str) -> bool:
         # Ideally models list is the best way to determine if api key is valid
         # Some of the OpenAI compatible vendors do not support all the methods though
         # client.models.list()
-        chat_completion = client.chat.completions.create(
-            messages=[
+        completion_args = {
+            'messages': [
                 {
                     'role': 'system',
                     'content': 'You are an AI assistant',
@@ -241,13 +241,18 @@ def is_api_key_valid(api_key: str, base_url: str, model: str) -> bool:
                     'content': 'Are you online',
                 }
             ],
-            model=model,
-            # Openai model 03-mini does not support max_tokens parameter.
-            # We do not support this model out of the box.
-            # Comment this line to use 03-mini model
-            max_tokens=1024
-            # max_completion_tokens=1024
-            )
+            'model': model,
+        }
+
+        normalized_model = model.lower()
+        modern_token_limit_prefixes = ('gpt-5', 'o1', 'o3', 'o4')
+        if normalized_model.startswith(modern_token_limit_prefixes):
+            completion_args['max_completion_tokens'] = 1024
+        else:
+            # Preserve compatibility with older OpenAI-compatible providers.
+            completion_args['max_tokens'] = 1024
+
+        chat_completion = client.chat.completions.create(**completion_args)
         assert len(chat_completion.choices[0].message.content) > 0
         client.close()
     except openai.AuthenticationError as e:


### PR DESCRIPTION
## Summary

Adds an optional native OpenAI Realtime speech-to-text backend selected with `-stt openai-realtime`.

- keeps one persistent `gpt-live-transcribe` WebSocket session for the microphone (`You`) and one for Windows WASAPI loopback (`Speaker`)
- captures small PCM blocks continuously, normalizes each source independently to mono PCM16/24 kHz, and preserves resampler state across block boundaries
- shows replaceable partial text through the existing UI queue, while persisting only confirmed `completed` items to Conversation, the database, LLM context, and transcript export
- reconciles events by OpenAI `item_id`, suppresses duplicate completions, bounds audio/event queues, and reconnects each source independently
- wires source enable/disable, pause/resume, clear, and shutdown into the existing desktop lifecycle
- adds configuration, CLI/provider composition, simulated-WebSocket tests, capture tests, and user documentation

## Architecture and compatibility

This builds on the rolling live transcription work merged in #293, but uses a streaming adapter rather than WAV-window overlap reconciliation. The existing Whisper/file backends and their rolling manager remain unchanged.

Open PR #294 touches some of the same integration files (`conversation.py`, `parameters.yaml`, `providers/stt.py`, `requirements.txt`, and provider tests). This backend declares `supports_diarization = False`; `gpt-live-transcribe` does not provide individual speaker labels. The changes are structurally compatible, but the dependency line and nearby integration blocks may need a small conflict resolution if #294 lands first. This PR intentionally leaves the existing `openai` SDK pin unchanged and adds the isolated `websocket-client` dependency.

## Testing

Python 3.11 on Windows:

- `python -m unittest discover -q app/transcribe/tests` — 85 passed, 6 skipped
- `python -m unittest discover -q tests` — 25 passed, 5 skipped
- `python -m unittest discover -q tsutils` — 8 passed
- `python -m unittest discover -q app/transcribe/db/tests` — 14 passed
- `python -m compileall -q sdk app/transcribe` — passed
- `git diff --check` — passed
- Bandit (`-ll`) on the new streaming path — no medium/high findings

The test suite covers microphone only, speaker only, both sources, PCM conversion/resampling, session configuration, partial/completed events, duplicate suppression, commit/clear, disconnect/reconnect, missing credentials, and sanitized API errors. A real connection-only smoke test is included but skipped unless `TRANSCRIBE_OPENAI_REALTIME_SMOKE=1` and `OPENAI_API_KEY` are set.

## Limitations and operational notes

- `Speaker` is the mixed Windows loopback output; Discord participants are not separated individually.
- The default uses OpenAI server VAD, so turn boundaries depend on the configured silence/threshold values.
- API usage is billed separately from ChatGPT; enabling both sources processes two live streams.
- Raw audio and credentials are not logged. Existing application shutdown behavior may still save local microphone/speaker WAV files.
- No live paid smoke test was run because no API key or audio device is required for the deterministic suite.

Repository searches did not find an existing issue or PR for this specific Realtime backend. No separate architecture issue was opened because the current provider composition accommodates the feature without a maintainer decision.
